### PR TITLE
docs: add CHANGELOG.md, docs/ folder, and rewrite README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,94 @@
+# Changelog
+
+All notable changes to Simple WP Helpdesk are documented here.
+
+---
+
+## [1.5] — 2026-03-27
+
+### Added
+- **Admin Ticket Creation:** Admins can now enter a client's Name and Email directly from the Add New Ticket screen in the WordPress dashboard.
+- **Portal Page Setting:** New `Helpdesk Page` dropdown in the Assignment & Routing tab. Selects the page containing `[submit_ticket]`; used to build the secure portal URL for admin-created tickets.
+- **Rate Limiting:** 30-second transient-based cooldown on all frontend actions (close, reopen, reply) to prevent duplicate submissions.
+- **Upload Error Logging:** Failed uploads (oversized files, `wp_handle_upload()` errors) now logged via `error_log()` instead of being silently discarded.
+
+### Fixed
+- **`swh_delete_on_uninstall` Silent Reset:** The "Delete data on uninstall" checkbox was resetting to `no` whenever any other settings tab was saved. Fixed by giving the Tools form its own nonce (`swh_save_tools_action`) and processing `swh_delete_on_uninstall` exclusively in that handler.
+- **Double-Escaped Author Names:** Special characters (apostrophes, accented letters) in technician names were being double-escaped and rendered as HTML entities in the conversation timeline.
+- **Retention Cron Active-Ticket Bug:** The attachment retention cron was using `post_date` for its age query, meaning it could delete attachments from recently-updated (but old) tickets. Fixed to use `post_modified`.
+- **Multi-Handler Firing:** Sequential `if` blocks for the frontend portal (close / reopen / reply) could theoretically fire multiple handlers in one request. Converted to `if/elseif/elseif`.
+- **GitHub Auto-Updater:** Resolved a fatal "No valid plugins were found" installation error introduced in versions ≤ 1.4.
+
+### Improved
+- **Single Source of Truth:** All option defaults now live exclusively in `swh_get_defaults()`. Hardcoded `add_option` calls removed from the upgrade routine.
+- **PRG Pattern:** All settings saves now perform a Post/Redirect/Get redirect, preventing double-submission on page refresh. Active tab is preserved via `?swh_tab=` query parameter.
+- **Input Validation:** Status, priority, and assignee values are validated against their allowed lists in `swh_save_ticket_data()` before being persisted.
+- **Assignee Role Check:** Assigned user ID is verified to belong to the `administrator` or `technician` role before saving.
+- **Integer Sanitization:** `swh_autoclose_days`, `swh_max_upload_size`, retention days, and `swh_ticket_page_id` are now saved with `absint()`.
+- **JS Reset Button:** Reset-to-default buttons now use a `data-field-name` attribute lookup instead of fragile `previousElementSibling` DOM traversal.
+- **`swh_field()` Function:** Moved from a nested closure inside `swh_render_settings_page()` to a top-level named function, eliminating a potential fatal error risk.
+
+### Removed
+- **`@set_time_limit(0)`:** Removed from all three cron functions — the micro-batch design makes it unnecessary.
+- **Duplicate `wp_head` Script Injection:** Removed redundant `wp_head` action for reCAPTCHA/Turnstile scripts; the shortcode now handles its own script loading with explicit render mode.
+
+---
+
+## [1.4] — 2025
+
+### Fixed
+- Fatal installation error ("No valid plugins were found") during automatic GitHub-based updates.
+
+### Improved
+- **Smart Folder-Flattening:** The GitHub Updater now automatically detects plugin files nested inside a sub-directory within the release archive and extracts them correctly.
+- **Release Asset Priority:** The updater now prioritizes pre-built `.zip` release assets over raw GitHub source archives for cleaner, safer updates.
+- **Cache Busting:** Implemented cache-busting on the update checker transient so new releases are detected immediately without waiting for the 12-hour timeout.
+
+---
+
+## [1.3] — 2025
+
+### Security
+- Fixed several security vulnerabilities identified by automated scanning tools.
+
+---
+
+## [1.2] — 2025
+
+### Added
+- **GitHub Auto-Updater:** The plugin now checks its linked GitHub repository for new releases and delivers them directly to the WordPress dashboard, functioning identically to a wordpress.org-hosted plugin.
+
+### Optimized
+- **Background Cron Overhaul:** Auto-Close, Ticket Purge, and Attachment Purge tasks are now split into separate staggered hourly events with strict SQL-level micro-batching (1–2 items per run). Eliminates cURL error 28 timeouts on resource-restricted hosts.
+- **Centralized Defaults:** Default configuration values consolidated into a statically cached object, reducing memory usage on every page load and guaranteeing fallback text when settings have not been explicitly saved.
+
+### Security
+- Enhanced frontend token validation with `hash_equals()` to protect the client portal against timing attacks.
+- Added strict path-traversal prevention to data retention file unlinking functions.
+- Added explicit `current_user_can` checks to backend save routines to prevent privilege escalation.
+
+---
+
+## [1.1] — 2025
+
+### Improved
+- **Page Builder Compatibility:** Frontend shortcode now uses a fully scoped CSS architecture under `.swh-helpdesk-wrapper`, keeping form elements correctly aligned inside Elementor columns.
+
+### Updated
+- Modernized frontend UI with improved padding, focus states, badge designs, and alert box styling.
+- Replaced raw inline HTML tags around form inputs with structured `<div>` groups to prevent theme line-height layout conflicts.
+
+---
+
+## [1.0] — 2025 — Initial Release
+
+### Added
+- Custom Post Type (`helpdesk_ticket`) for native WordPress backend integration.
+- Front-end submission form and secure token-based client portal via `[submit_ticket]` shortcode.
+- Tabbed Admin Settings panel: General, Assignment & Routing, Email Templates, Messages, Anti-Spam, Tools.
+- Two-way multi-file upload support with JavaScript size and extension validation.
+- Technician UI with public reply and private Internal Note capabilities.
+- Background automation: auto-close inactive resolved tickets; auto-purge old tickets and attachments.
+- GDPR client data purge tool and full uninstallation cleanup routines.
+- Anti-spam integrations: Honeypot, Google reCAPTCHA v2, Cloudflare Turnstile.
+- Micro-batched cron jobs to prevent server timeouts.

--- a/README.md
+++ b/README.md
@@ -1,148 +1,69 @@
-SIMPLE WP HELPDESK
+# Simple WP Helpdesk
 
-- Latest Version: 1.4
-- Requires Wordpress: 5.3+
-- Requires PHP: 7.2+
+A comprehensive, lightweight ticketing system built natively for WordPress. No third-party services required — all client data stays on your own server.
 
-PLUGIN DESCRIPTION
+**Version:** 1.5 &nbsp;|&nbsp; **Requires WordPress:** 5.3+ &nbsp;|&nbsp; **Requires PHP:** 7.2+
 
-A comprehensive, lightweight, and secure ticketing system built natively for WordPress. Keep your client data entirely on your own server.
+---
 
-IMPORTANT NOTE
+## Features
 
-This plugin is a Work in Progress and there may be bugs or security issues.  I have tried my best to test all functionality and make the plugin secure.  Please raise an issue if you find any bugs or security issues or have any functionality requests.  I am working on implementing some automated testing for this plugin.
+- **Secure Client Portal** — Clients view and reply to tickets via unique cryptographic email links, no WordPress account needed.
+- **Customizable Workflows** — Define your own ticket statuses and priority levels.
+- **Email Templates** — 16 fully customizable email templates with dynamic placeholders.
+- **File Attachments** — Two-way multi-file uploads for clients and technicians, with configurable size limits and instant JavaScript validation.
+- **Internal Notes** — Technicians can leave private notes clients never see.
+- **Admin Ticket Creation** — Create tickets on behalf of clients directly from the WordPress dashboard, with optional confirmation email.
+- **Automation** — Background cron jobs auto-close resolved tickets after configurable inactivity.
+- **Data Retention & GDPR** — Auto-purge old attachments and tickets; GDPR-compliant per-email data deletion.
+- **Anti-Spam** — Built-in Honeypot, Google reCAPTCHA v2, and Cloudflare Turnstile support.
+- **Page Builder Friendly** — Scoped CSS keeps the frontend form correctly styled inside Elementor and similar builders.
+- **Automatic Updates** — Built-in GitHub auto-updater delivers new releases directly to your WordPress dashboard.
 
-0. ORIGINS
+---
 
-I was looking for a lightweight, simple and easy to setup helpdesk plugin for Wordpress that was free.   My search didn't go well.  I resorted to just a standard E-mail form but really wanted better tracking.  So, I did what any other "normal" person would do and I sat down with Google Gemini and some ideas of what functionality I wanted and pounded out a helpdesk plugin that did everything that I wanted.  This is the result of it.
+## Quick Start
 
-1. FEATURE SUMMARY
+1. Download `simple-wp-helpdesk.zip` from the [latest release](https://github.com/seanmousseau/Simple-WP-Helpdesk/releases/latest).
+2. In WordPress, go to **Plugins → Add New → Upload Plugin** and install the ZIP.
+3. Activate the plugin. A **Tickets** menu item appears in the dashboard.
+4. Create a page (e.g., "Support") and add the shortcode `[submit_ticket]` to it.
+5. Go to **Tickets → Settings → Assignment & Routing** and set the **Helpdesk Page** to the page you just created.
 
-- Secure Client Portal: Clients can submit, view, and reply to tickets from the front-end without needing a WordPress user account. Access is secured via unique cryptographic email tokens.
-- Customizable Workflows: Fully customizable ticket statuses and priority levels to fit your business logic.
-- Smart Communications: Highly customizable email templates with dynamic placeholders. 
-- File Attachments: Two-way, multi-file uploading for clients and technicians. Includes customizable size limits, secure file type checking, and instant JavaScript validation.
-- Internal Notes: Technicians can leave private internal notes on tickets that clients cannot see.
-- Automation Engine: Background cron jobs can automatically close resolved tickets after a configured amount of inactivity.
-- Data Retention & GDPR: Tools to automatically purge old attachments/tickets, permanently delete specific client data by email, and perform a complete plugin factory reset.
-- Robust Anti-Spam: Built-in Honeypot, Google reCAPTCHA v2, and Cloudflare Turnstile integrations.
-- Page Builder Friendly: Scoped CSS architecture ensures the frontend UI looks perfect inside Elementor and other modern page builders.
+That's it — your helpdesk is live.
 
-2. INSTALLATION
+---
 
-Installing the plugin via a .zip file is quick and easy through the standard WordPress dashboard.
+## Documentation
 
-Prerequisites: Ensure you have the "simple-wp-helpdesk.zip" file saved to your computer.
+| Guide | Description |
+|-------|-------------|
+| [Installation](docs/installation.md) | Detailed install steps, auto-updates, and uninstall |
+| [Configuration](docs/configuration.md) | All settings tabs explained |
+| [Usage](docs/usage.md) | Guide for clients and technicians |
+| [Security](docs/security.md) | Token auth, anti-spam, nonces, input handling |
+| [Development](docs/development.md) | Architecture, coding conventions, and release process |
 
-1. Log in to your WordPress Admin Dashboard (e.g., yoursite.com/wp-admin).
-2. On the left-hand menu, navigate to Plugins > Add New.
-3. At the top of the screen, click the "Upload Plugin" button.
-4. Click "Choose File" (or "Browse") and select the simple-wp-helpdesk.zip file from your computer.
-5. Click "Install Now".
-6. Once WordPress finishes unpacking the file, click the "Activate Plugin" button.
-7. Setup Complete! You will now see a "Tickets" menu item on the left side of your dashboard.
+---
 
-NEXT STEP (FRONTEND SETUP):
-To display the helpdesk to your users, create a new WordPress Page (e.g., "Support") and place the following shortcode anywhere on the page:
-[submit_ticket]
+## Changelog
 
-3. CONFIGURATION
+See [CHANGELOG.md](CHANGELOG.md) for the full version history.
 
-To configure the plugin, navigate to Tickets > Settings in your WordPress dashboard. The settings are divided into six tabs:
+---
 
-TAB 1: GENERAL
-- Custom Priorities & Statuses: Define your workflow by entering comma-separated values (e.g., Open, In Progress, Resolved, Closed).
-- Default Statuses: Tell the system which status represents a New ticket, a Resolved ticket (which triggers the auto-close timer), a Closed ticket (which disables normal replies), and a Re-Opened ticket.
-- Max File Upload Size: Set the maximum Megabyte (MB) limit per file upload.
+## Known Issues
 
-TAB 2: ASSIGNMENT & ROUTING
-- Default Assignee: Select a specific technician from the dropdown. All new tickets will be automatically assigned to this user.
-- Fallback Alert Email: If a ticket is unassigned, system notifications (new tickets, client replies) will be sent to this email address instead of the primary Site Admin.
+- GitHub Auto-Update is broken in versions 1.3 and earlier. Upgrade to 1.4+ to restore update functionality.
 
-TAB 3: EMAIL TEMPLATES
-- Customize the Subject and Body of every email the system sends out.
-- Use Placeholders to dynamically insert data. Available placeholders include: {name}, {email}, {ticket_id}, {title}, {status}, {priority}, {message}, {autoclose_days}, {ticket_url} (Frontend link for clients), and {admin_url} (Backend link for technicians).
-- Note: If you need to revert a template, click the red "Reset to default" link below the text box.
+---
 
-TAB 4: MESSAGES
-- Customize the front-end text displayed to the user when they successfully submit forms, reply to tickets, or trigger errors (like failing the anti-spam check).
+## Contributing
 
-TAB 5: ANTI-SPAM
-- Method: Choose between None, Honeypot (invisible trap for bots), Google reCAPTCHA v2, or Cloudflare Turnstile.
-- If using reCAPTCHA or Turnstile, paste your public Site Key and Secret Key here. The widgets will automatically render on your front-end form.
+Bug reports, security disclosures, and feature requests are welcome — please open an issue on [GitHub](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues).
 
-TAB 6: TOOLS
-- Automated Data Retention: Configure background tasks. Set how many days to keep physical file attachments before deleting them to save server space, and how many days to keep entirely inactive tickets before purging them. Set to 0 to disable.
-- Uninstallation Behavior: Check this box if you want WordPress to securely wipe all tickets, files, and settings when you delete the plugin.
-- Danger Zone: Manual tools to Purge all tickets, Factory Reset the plugin, or perform a GDPR-compliant purge of a specific client's email address and data.
+---
 
-4. USAGE
+## License
 
-PART A: FOR CLIENTS / END-USERS
-
-Submitting a Ticket:
-1. Navigate to the Support page on the website.
-2. Fill out your Name, Email, Priority, Summary (Title), and a detailed Description.
-3. Click "Choose Files" to attach any relevant screenshots or documents.
-4. Click Submit Ticket. You will receive an email confirmation containing a secure tracking link.
-
-Managing an Existing Ticket:
-1. Open the confirmation email and click the secure tracking link.
-2. You will be taken to your private ticket portal to see the current status and conversation history.
-3. To Reply: Type your message in the reply box, attach files if necessary, and click Send Reply.
-4. To Close: If a technician marks the ticket as "Resolved", a blue banner will appear allowing you to officially close the ticket yourself.
-5. To Re-open: If a ticket is marked "Closed", the standard reply box is replaced by a "Re-open Ticket" form. Fill it out to alert the technicians that you still need help.
-
-PART B: FOR TECHNICIANS / ADMINS
-
-Viewing and Managing Tickets:
-1. Log into the WordPress Dashboard and click Tickets.
-2. Click on a ticket's Title to open the Ticket Editor.
-3. On the right-hand sidebar (Ticket Details), you will see the client's information, aggregate links to all attached files, and dropdowns to update the Assignee, Priority, and Status.
-
-Communicating with Clients:
-1. Scroll down to the Conversation & Reply box. Here you will see the timeline.
-2. Public Reply: Type in the left-hand box and attach files. This will be emailed to the client.
-3. Internal Note: Type in the yellow right-hand box. This will only be visible to other logged-in technicians. The client will not see this or receive an email.
-4. Saving: Once you have typed your reply and/or updated the status dropdowns on the right, scroll up and click the blue "Update" button on the right-hand side.
-   (Pro-Tip: If you type a public reply AND change the status to Closed/Resolved simultaneously, the system will smartly combine these actions into a single email notification for the client.)
-
-5. CHANGELOG
-
-VERSION 1.4
-
-- Fix: Resolved a fatal installation error ("No valid plugins were found") during automatic updates.
-- Improved: The GitHub Updater now utilizes "Smart Folder-Flattening". It automatically detects if the plugin files are nested inside a sub-directory within the GitHub repository and extracts them correctly into the WordPress plugins folder.
-- Improved: The updater now prioritizes downloading attached compiled .zip release assets over the raw GitHub source code for cleaner, safer updates.
-Optimized: Implemented cache-busting on the transient update checker to ensure new releases are detected immediately without waiting for the 12-hour timeout.
-
-VERSION 1.3
-- Security: Fixed several security issues found by automated tools.
-
-VERSION 1.2
-- Added: Native GitHub auto-updater. The plugin now securely checks the linked GitHub repository for new releases and serves them directly to the WordPress dashboard, functioning identically to an official repository plugin.
-- Optimized: Completely overhauled the background maintenance crons. Tasks (Auto-Close, Ticket Purge, Attachment Purge) are now split into separate staggered events and use strict SQL-level filtering to process tiny micro-batches. This completely eliminates the "cURL error 28" timeout issue on resource-restricted web hosts.
-- Optimized: Centralized the default configuration engine into a statically cached object to drastically lower memory usage on every page load and guarantee fallback text if settings are not explicitly saved.
-- Security: Enhanced the frontend cryptographic token validation logic, utilizing hash_equals() to protect the client portal against advanced timing attacks.
-- Security: Added strict path-traversal prevention to the data retention file unlinking functions.
-- Security: Added explicit authorization checks (current_user_can) to the backend save routines to prevent privilege escalation.
-
-VERSION 1.1
-- Improved: Elementor Page Builder compatibility. The frontend shortcode now utilizes a completely scoped CSS architecture. This forces internal form elements to remain neatly left-aligned even if the surrounding Elementor column is center-justified. 
-- Updated: Modernized the frontend UI with better padding, focus states, badge designs, and alert box styling for a more professional appearance out-of-the-box.
-- Updated: Swapped raw inline HTML tags around form inputs for structured DIV groups to prevent theme line-height layout conflicts.
-
-VERSION 1.0 (Initial Release)
-- Added: Custom Post Type for native WordPress backend integration.
-- Added: Front-end submission form and secure token-based client portal via shortcode.
-- Added: Tabbed Admin Settings panel for configuring General Settings, Routing, Emails, Messages, Anti-Spam, and Tools.
-- Added: 2-way multi-file upload support with JavaScript size and extension validation.
-- Added: Dedicated Technician UI with public reply and private "Internal Note" capabilities.
-- Added: Background Automation (Auto-Close inactive resolved tickets, Auto-Purge old tickets/attachments).
-- Added: GDPR Client Data Purge tool and deep uninstallation cleanup routines.
-- Added: Honeypot, Google reCAPTCHA v2, and Cloudflare Turnstile anti-spam integrations.
-- Optimized: Micro-batched cron jobs to prevent server timeouts (cURL error 28).
-
-6. KNOWN ISSUES AND UNTESTED FUNCTIONALITY
-
-- GitHub Auto Update is broken in version 1.3 and older.  Issues are resolved in version 1.4.
+See [LICENSE](LICENSE) for details.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,120 @@
+# Configuration
+
+Navigate to **Tickets → Settings** in your WordPress dashboard. Settings are organized across six tabs.
+
+---
+
+## Tab 1: General
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| **Ticket Priorities** | Comma-separated list of priority levels | `Low, Medium, High` |
+| **Ticket Statuses** | Comma-separated list of workflow statuses | `Open, In Progress, Resolved, Closed` |
+| **Default Priority** | Priority assigned to new tickets | `Medium` |
+| **Default Status** | Status assigned to new tickets | `Open` |
+| **Resolved Status** | Triggers the auto-close countdown | `Resolved` |
+| **Closed Status** | Disables further client replies | `Closed` |
+| **Re-Opened Status** | Assigned when a client re-opens a closed ticket | `Open` |
+| **Auto-Close Days** | Days after "Resolved" before automatic closure (0 = disabled) | `3` |
+| **Max Upload Size** | Maximum file size per upload in MB | `5` |
+
+---
+
+## Tab 2: Assignment & Routing
+
+| Setting | Description |
+|---------|-------------|
+| **Default Assignee** | Technician automatically assigned to every new ticket |
+| **Fallback Alert Email** | Receives new-ticket and client-reply notifications when no assignee is set |
+| **Helpdesk Page** | The WordPress page containing `[submit_ticket]`; used to build portal URLs for admin-created tickets |
+
+**Email routing priority** (when sending admin notifications):
+1. The ticket's assigned technician
+2. The default assignee (if set)
+3. The fallback alert email (if set)
+4. The site admin email
+
+---
+
+## Tab 3: Email Templates
+
+Customize the subject line and body of every email the plugin sends. Click **Reset to default** below any template to restore the original text.
+
+**Available placeholders:**
+
+| Placeholder | Value |
+|-------------|-------|
+| `{name}` | Client's name |
+| `{email}` | Client's email address |
+| `{ticket_id}` | Unique ticket ID (e.g. `TKT-0001`) |
+| `{title}` | Ticket title / summary |
+| `{status}` | Current ticket status |
+| `{priority}` | Current priority level |
+| `{message}` | Message body |
+| `{ticket_url}` | Secure client portal link |
+| `{admin_url}` | WordPress admin edit link (technicians only) |
+| `{autoclose_days}` | Configured auto-close threshold |
+
+**Email events (16 total):**
+- New ticket submitted
+- New ticket assigned to technician
+- Technician public reply
+- Client reply received
+- Status changed
+- Ticket auto-closed
+- Ticket re-opened by client
+- ... and more
+
+---
+
+## Tab 4: Messages
+
+Customize the front-end text shown to clients after form actions:
+
+| Message Key | When Shown |
+|-------------|-----------|
+| Success — New Ticket | After a ticket is successfully submitted |
+| Success — Reply Sent | After a client reply is sent |
+| Success — Ticket Closed | After a client closes a resolved ticket |
+| Success — Ticket Re-Opened | After a client re-opens a closed ticket |
+| Error — Spam Check Failed | Anti-spam validation failed |
+| Error — Invalid Token | Ticket portal URL is invalid or expired |
+| Error — General | Catch-all for unexpected errors |
+
+---
+
+## Tab 5: Anti-Spam
+
+| Method | Description |
+|--------|-------------|
+| **None** | No anti-spam protection |
+| **Honeypot** | Invisible hidden field; catches basic bots with no user friction |
+| **Google reCAPTCHA v2** | "I'm not a robot" checkbox; requires Site Key + Secret Key |
+| **Cloudflare Turnstile** | Privacy-friendly CAPTCHA alternative; requires Site Key + Secret Key |
+
+For reCAPTCHA and Turnstile, paste your public **Site Key** and private **Secret Key** into the respective fields. The widget renders automatically on the frontend form.
+
+---
+
+## Tab 6: Tools
+
+### Automated Data Retention
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| **Attachment Retention Days** | Delete physical files older than N days (0 = disabled) | `0` |
+| **Ticket Retention Days** | Delete entire tickets inactive for N days (0 = disabled) | `0` |
+
+Retention jobs run hourly in micro-batches to avoid server timeouts.
+
+### Uninstallation
+
+Check **Delete all plugin data on uninstall** to permanently remove all tickets, attachments, and settings when the plugin is deleted from WordPress.
+
+### Danger Zone
+
+| Action | Effect |
+|--------|--------|
+| **Purge All Tickets** | Permanently deletes every ticket and its attachments |
+| **GDPR Email Purge** | Deletes all tickets, replies, and files associated with a specific email address |
+| **Factory Reset** | Resets all settings to defaults; does not delete tickets |

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,161 @@
+# Development Guide
+
+---
+
+## Repository Structure
+
+```
+Simple-WP-Helpdesk/
+├── CHANGELOG.md
+├── CLAUDE.md                            # AI assistant guidance
+├── README.md
+├── LICENSE
+├── composer.json                        # Dev dependencies (PHPUnit, PHPCS, WPCS)
+├── composer.lock
+├── simple-wp-helpdesk.zip               # Distribution archive
+├── vendor/                              # Composer dev tools (not distributed)
+├── docs/                                # This documentation
+└── simple-wp-helpdesk/
+    ├── simple-wp-helpdesk.php           # Entire plugin — single file
+    └── phpcs.xml                        # PHP CodeSniffer ruleset
+```
+
+> All plugin logic lives in **one file**: `simple-wp-helpdesk/simple-wp-helpdesk.php`.
+
+---
+
+## Setting Up
+
+```bash
+# Clone the repository
+git clone https://github.com/seanmousseau/Simple-WP-Helpdesk.git
+cd Simple-WP-Helpdesk
+
+# Install dev dependencies
+composer install
+```
+
+---
+
+## Code Quality
+
+### PHP CodeSniffer (WordPress Coding Standards)
+
+```bash
+# Check for violations
+vendor/bin/phpcs --standard=simple-wp-helpdesk/phpcs.xml simple-wp-helpdesk/simple-wp-helpdesk.php
+
+# Auto-fix fixable violations
+vendor/bin/phpcbf --standard=simple-wp-helpdesk/phpcs.xml simple-wp-helpdesk/simple-wp-helpdesk.php
+```
+
+### PHPUnit
+
+```bash
+vendor/bin/phpunit
+```
+
+> Note: Automated test coverage is in progress. Test files are not yet present.
+
+---
+
+## Architecture Overview
+
+### No Custom Database Tables
+
+The plugin uses only WordPress core data structures:
+
+| Data | Storage | Key Meta |
+|------|---------|----------|
+| Tickets | `helpdesk_ticket` Custom Post Type | `_ticket_uid`, `_ticket_token`, `_ticket_status`, `_ticket_priority`, `_ticket_email`, etc. |
+| Replies & Notes | WP Comments on the CPT | `_is_internal_note`, `_is_user_reply`, `_attachments` |
+| Settings | `wp_options` | All keys prefixed with `swh_` |
+
+### Function Naming
+
+All functions use the `swh_` prefix:
+
+```php
+swh_activate()
+swh_get_defaults()
+swh_ticket_frontend()
+swh_save_ticket_data()
+```
+
+### Single Source of Truth for Defaults
+
+**`swh_get_defaults()`** is the definitive list of every plugin option and its default value. It uses a `static $defaults` cache so it is only built once per request.
+
+When adding a new option:
+1. Add it to `swh_get_defaults()` with its default value.
+2. It will automatically be registered by the upgrade routine, included in factory reset, and cleaned up on uninstall.
+
+---
+
+## Adding Features
+
+### New Option
+
+1. Add to `swh_get_defaults()`:
+   ```php
+   'swh_my_new_option' => 'default_value',
+   ```
+2. Add the field to the appropriate settings tab in `swh_render_settings_page()`.
+3. Add it to the correct save handler (`swh_handle_settings_save()` or `swh_handle_tools_save()`).
+
+### New Email Template
+
+Add both variants to `swh_get_defaults()`:
+```php
+'swh_my_event_sub'  => 'Subject: {ticket_id}',
+'swh_my_event_body' => 'Hello {name}, ...',
+```
+
+### New Cron Job
+
+1. Register in `swh_activate()`:
+   ```php
+   wp_schedule_event( time() + OFFSET_SECONDS, 'hourly', 'swh_my_event' );
+   ```
+2. Clear in `swh_deactivate()`:
+   ```php
+   wp_clear_scheduled_hook( 'swh_my_event' );
+   ```
+3. Hook the handler:
+   ```php
+   add_action( 'swh_my_event', 'swh_process_my_event' );
+   ```
+4. Use a different offset from existing jobs (currently: +0 min, +30 min, +60 min) to avoid simultaneous execution.
+
+---
+
+## Settings Forms — Two Nonces
+
+There are **two separate forms** on the settings page, each with its own nonce:
+
+| Form | Nonce Action | Nonce Field | Owns |
+|------|-------------|-------------|------|
+| Main settings | `swh_save_settings_action` | `swh_settings_nonce` | Everything except Tools tab |
+| Tools form | `swh_save_tools_action` | `swh_tools_nonce` | `swh_retention_*`, `swh_delete_on_uninstall` |
+
+Never move `swh_delete_on_uninstall` or retention settings to the main form handler — they will reset silently.
+
+---
+
+## Building a Release ZIP
+
+```bash
+zip -r simple-wp-helpdesk.zip simple-wp-helpdesk/ --exclude "simple-wp-helpdesk/phpcs.xml"
+```
+
+The resulting archive contains `simple-wp-helpdesk/simple-wp-helpdesk.php` and is ready for direct upload to WordPress or attachment to a GitHub release.
+
+---
+
+## Versioning
+
+1. Update `Version:` in the plugin header comment inside `simple-wp-helpdesk.php`.
+2. Update `define( 'SWH_VERSION', 'X.Y' )`.
+3. If the settings schema changed, add an upgrade path in `swh_run_upgrade_routine()`.
+4. Add a version entry to `CHANGELOG.md`.
+5. Build and attach the release ZIP to the GitHub release. The tag name must match the `Version:` header for the auto-updater to work correctly.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,50 @@
+# Installation
+
+## Requirements
+
+| Requirement | Minimum |
+|-------------|---------|
+| WordPress   | 5.3+    |
+| PHP         | 7.2+    |
+
+---
+
+## Installing via ZIP Upload (Recommended)
+
+1. Download `simple-wp-helpdesk.zip` from the [latest GitHub release](https://github.com/seanmousseau/Simple-WP-Helpdesk/releases/latest).
+2. In your WordPress dashboard, go to **Plugins → Add New**.
+3. Click **Upload Plugin** at the top of the screen.
+4. Click **Choose File**, select `simple-wp-helpdesk.zip`, then click **Install Now**.
+5. Click **Activate Plugin** once installation is complete.
+
+A **Tickets** menu item will now appear in the left-hand dashboard sidebar.
+
+---
+
+## Setting Up the Frontend
+
+Create a WordPress page (e.g., "Support") and add the following shortcode to its content:
+
+```
+[submit_ticket]
+```
+
+This page serves as both the ticket submission form and the secure client portal. Record the page ID — you will need it in **Settings → Assignment & Routing → Helpdesk Page**.
+
+---
+
+## Automatic Updates
+
+The plugin includes a built-in GitHub auto-updater. When a new release is published, WordPress will display the standard "Update Available" notice in **Plugins** and allow one-click updating — no manual ZIP download required.
+
+---
+
+## Uninstalling
+
+To remove the plugin and optionally all its data:
+
+1. Go to **Tickets → Settings → Tools**.
+2. Check **Delete all plugin data on uninstall** if you want tickets, attachments, and settings permanently removed.
+3. Go to **Plugins**, deactivate, then delete Simple WP Helpdesk.
+
+If the delete-on-uninstall option is not checked, WordPress tables and options are left intact so reinstalling restores all data.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,93 @@
+# Security
+
+Simple WP Helpdesk is built with WordPress security best practices. This document summarizes the key security mechanisms in place.
+
+---
+
+## Client Portal Authentication
+
+Access to ticket details is controlled by a **cryptographic token** appended to each ticket's URL:
+
+```
+https://yoursite.com/support/?swh_ticket=123&token=AbCdEfGhIjKlMnOpQrSt
+```
+
+- Tokens are generated with `wp_generate_password(20, false)` — 20 random alphanumeric characters.
+- Token comparisons always use `hash_equals()` to prevent timing-based brute-force attacks.
+- Tokens are stored as post meta and never exposed in the admin-facing ticket list.
+
+---
+
+## Anti-Spam
+
+Three methods are available (configured in **Settings → Anti-Spam**):
+
+| Method | How It Works |
+|--------|-------------|
+| **Honeypot** | A hidden form field invisible to real users; bots that fill it are silently rejected |
+| **Google reCAPTCHA v2** | Server-side verification with Google's API before ticket submission is accepted |
+| **Cloudflare Turnstile** | Privacy-friendly challenge verified server-side before processing |
+
+---
+
+## Frontend Rate Limiting
+
+All frontend form actions (submit reply, close ticket, re-open ticket) enforce a **30-second cooldown** per client via WordPress transients. This prevents accidental double-submissions and basic abuse.
+
+---
+
+## Form & Nonce Validation
+
+Every form submission — both frontend and admin — is protected by a **WordPress nonce**:
+
+- Frontend submission form: `swh_submit_ticket_nonce`
+- Frontend reply / close / re-open: verified before any action is taken
+- Admin settings (main form): `swh_save_settings_action` / `swh_settings_nonce`
+- Admin settings (Tools form): `swh_save_tools_action` / `swh_tools_nonce`
+
+---
+
+## Capability Checks
+
+All admin-side operations check WordPress capabilities before executing:
+
+| Operation | Required Capability |
+|-----------|-------------------|
+| Save plugin settings | `manage_options` |
+| Save ticket meta (status, assignee, etc.) | `edit_post` on that ticket |
+| GDPR purge / factory reset | `manage_options` |
+
+---
+
+## Input Sanitization & Output Escaping
+
+All user input is sanitized on the way in and escaped on the way out:
+
+- **Text fields:** `sanitize_text_field()`
+- **Email fields:** `sanitize_email()`
+- **Textarea / message bodies:** `sanitize_textarea_field()`
+- **HTML fields (email templates):** `wp_kses_post()`
+- **Integer options:** `absint()`
+- **HTML output:** `esc_html()`, `esc_attr()`, `esc_url()`, `esc_js()`
+
+---
+
+## File Upload Security
+
+- File uploads are processed exclusively through WordPress's `wp_handle_upload()`.
+- **Allowed MIME types:** JPEG, PNG, GIF, PDF, DOC, DOCX, TXT.
+- Upload size is enforced both client-side (JavaScript) and server-side (PHP).
+- Files are stored in the standard WordPress uploads directory.
+- Before deleting any file, the path is validated to confirm it starts with the uploads directory, preventing path traversal attacks.
+
+---
+
+## Assignee Validation
+
+When saving a ticket, the assigned user ID is verified to belong to either the `administrator` or `technician` role. Invalid user IDs are silently discarded, preventing privilege escalation via forged form submissions.
+
+---
+
+## Reporting Vulnerabilities
+
+Please open an issue on [GitHub](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues) to report any security vulnerabilities or concerns.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,71 @@
+# Usage Guide
+
+---
+
+## For Clients / End Users
+
+### Submitting a Ticket
+
+1. Go to the Support page on the website.
+2. Fill in your **Name**, **Email**, **Priority**, **Summary** (title), and **Description**.
+3. Optionally click **Choose Files** to attach screenshots or documents.
+4. Click **Submit Ticket**.
+
+You will receive an email confirmation containing a secure tracking link unique to your ticket.
+
+### Viewing and Replying to a Ticket
+
+1. Open the confirmation email and click the secure tracking link.
+2. Your private ticket portal shows the current status, priority, and the full conversation history.
+3. To reply, type your message in the reply box, optionally attach files, and click **Send Reply**.
+
+### Closing a Ticket
+
+When a technician marks your ticket as **Resolved**, a banner appears in the portal with a **Close Ticket** button. Click it to formally close the ticket and notify the team.
+
+### Re-Opening a Ticket
+
+If a ticket is **Closed** but your issue is unresolved, the standard reply form is replaced with a **Re-Open Ticket** form. Submit it to alert the technicians.
+
+---
+
+## For Technicians / Administrators
+
+### Viewing Tickets
+
+1. Log into the WordPress dashboard and click **Tickets**.
+2. The ticket list shows all open tickets with their status, priority, and assignee.
+3. Click a ticket title to open the Ticket Editor.
+
+### Updating Ticket Details
+
+The **Ticket Details** sidebar (right-hand side) contains:
+- Client name and email
+- Assignee dropdown
+- Priority dropdown
+- Status dropdown
+- Links to all attached files
+
+After making changes, click the blue **Update** button at the top-right to save.
+
+### Public Replies
+
+1. Scroll down to the **Conversation & Reply** section.
+2. Type your reply in the left-hand text box. Attach files if needed.
+3. Click **Update** to save and send the reply to the client.
+
+> **Tip:** If you change the status to Resolved or Closed at the same time as sending a reply, the system sends a single combined email rather than two separate notifications.
+
+### Internal Notes
+
+Type in the **yellow** right-hand box to leave an internal note. Internal notes are visible only to logged-in technicians — clients never see them and receive no email notification.
+
+### Creating Tickets on Behalf of Clients
+
+1. Go to **Tickets → Add New**.
+2. Enter the ticket **Title** (summary) and **Description** in the standard post editor.
+3. In the **Ticket Details** sidebar, enter the client's **Name** and **Email**.
+4. Check **Send confirmation email to client** if you want the client to receive their portal link immediately.
+5. Set the desired **Priority** and **Status**, then click **Publish**.
+
+The ticket UID, secure token, and portal URL are auto-generated on the first save. The portal URL is based on the **Helpdesk Page** configured in **Settings → Assignment & Routing**.


### PR DESCRIPTION
## Summary

- Added `CHANGELOG.md` with full version history from v1.0 through v1.5, with categorized entries (Added / Fixed / Improved / Removed / Security)
- Created `docs/` folder with five reference guides: `installation.md`, `configuration.md`, `usage.md`, `security.md`, `development.md`
- Rewrote `README.md` with proper Markdown formatting, updated feature list for v1.5 (including admin ticket creation), 5-step quick start, and a table linking out to all docs pages

## Test plan

- [ ] Verify all links in `README.md` resolve correctly (docs table, CHANGELOG, LICENSE, GitHub issues)
- [ ] Review `CHANGELOG.md` entries for accuracy against the actual code changes in each version
- [ ] Check `docs/configuration.md` option tables match the defaults defined in `swh_get_defaults()`
- [ ] Confirm `docs/development.md` build and release instructions work end-to-end

https://claude.ai/code/session_01JQ9nksxaMUQfvGdEgS4WRZ