### PR TITLE
docs: clarify manual ZIP installation, not available on wordpress.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ That's it — your helpdesk is live.
 
 | Guide | Description |
 |-------|-------------|
-| [Installation](docs/installation.md) | Detailed install steps, auto-updates, and uninstall |
+| [Installation](docs/installation.md) | Manual ZIP install, automatic updates, and uninstall |
 | [Configuration](docs/configuration.md) | All settings tabs explained |
 | [Usage](docs/usage.md) | Guide for clients and technicians |
 | [Security](docs/security.md) | Token auth, anti-spam, nonces, input handling |

--- a/docs/development.md
+++ b/docs/development.md
@@ -148,7 +148,7 @@ Never move `swh_delete_on_uninstall` or retention settings to the main form hand
 zip -r simple-wp-helpdesk.zip simple-wp-helpdesk/ --exclude "simple-wp-helpdesk/phpcs.xml"
 ```
 
-The resulting archive contains `simple-wp-helpdesk/simple-wp-helpdesk.php` and is ready for direct upload to WordPress or attachment to a GitHub release.
+The resulting archive contains `simple-wp-helpdesk/simple-wp-helpdesk.php` and is ready for manual installation via the WordPress dashboard (**Plugins → Add New → Upload Plugin**) or for attachment to a GitHub release.
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,7 +9,9 @@
 
 ---
 
-## Installing via ZIP Upload (Recommended)
+## Installing the Plugin
+
+Simple WP Helpdesk is not listed on the WordPress.org plugin directory. It is installed manually via ZIP upload through the WordPress dashboard.
 
 1. Download `simple-wp-helpdesk.zip` from the [latest GitHub release](https://github.com/seanmousseau/Simple-WP-Helpdesk/releases/latest).
 2. In your WordPress dashboard, go to **Plugins → Add New**.


### PR DESCRIPTION
## Summary

- Corrected `docs/installation.md` to remove the "(Recommended)" label implying other install methods exist; added explicit note that the plugin is not listed on the WordPress.org directory and must be installed manually via ZIP upload
- Updated `README.md` docs table description to say "Manual ZIP install" rather than the ambiguous "Detailed install steps"
- Fixed `docs/development.md` release section wording — "direct upload to WordPress" implied a wordpress.org submission; replaced with the correct manual dashboard install path

## Test plan

- [x] Confirm `docs/installation.md` no longer implies alternative install methods exist
- [x] Verify all three changed files render correctly in GitHub Markdown preview

https://claude.ai/code/session_01JQ9nksxaMUQfvGdEgS4WRZ