### PR TITLE
fix: recover missing logo files from incomplete merge

### DIFF
--- a/simple-wp-helpdesk/admin/class-settings.php
+++ b/simple-wp-helpdesk/admin/class-settings.php
@@ -280,7 +280,10 @@ function swh_render_settings_page() {
 	$techs = get_users( array( 'role__in' => array( 'administrator', 'technician' ) ) );
 	?>
 	<div class="wrap">
-		<h2><?php esc_html_e( 'Helpdesk Settings', 'simple-wp-helpdesk' ); ?></h2>
+		<h2>
+			<img src="<?php echo esc_url( SWH_ICON_1X ); ?>" alt="" style="width:32px;height:32px;vertical-align:middle;margin-right:6px;border-radius:4px;">
+			<?php esc_html_e( 'Helpdesk Settings', 'simple-wp-helpdesk' ); ?>
+		</h2>
 		<div class="nav-tab-wrapper" id="swh-tabs" role="tablist" aria-label="<?php esc_attr_e( 'Settings Sections', 'simple-wp-helpdesk' ); ?>">
 			<button type="button" class="nav-tab nav-tab-active" role="tab" id="swh-tab-general" data-tab="tab-general" aria-selected="true" aria-controls="tab-general" tabindex="0"><?php esc_html_e( 'General', 'simple-wp-helpdesk' ); ?></button>
 			<button type="button" class="nav-tab" role="tab" id="swh-tab-routing" data-tab="tab-routing" aria-selected="false" aria-controls="tab-routing" tabindex="-1"><?php esc_html_e( 'Assignment & Routing', 'simple-wp-helpdesk' ); ?></button>

--- a/simple-wp-helpdesk/includes/class-installer.php
+++ b/simple-wp-helpdesk/includes/class-installer.php
@@ -283,7 +283,7 @@ function swh_register_ticket_cpt() {
 			),
 			'public'          => false,
 			'show_ui'         => true,
-			'menu_icon'       => SWH_ICON_1X,
+			'menu_icon'       => SWH_MENU_ICON,
 			'supports'        => array( 'title', 'editor' ),
 			'capability_type' => 'post',
 		)

--- a/simple-wp-helpdesk/includes/class-installer.php
+++ b/simple-wp-helpdesk/includes/class-installer.php
@@ -283,7 +283,7 @@ function swh_register_ticket_cpt() {
 			),
 			'public'          => false,
 			'show_ui'         => true,
-			'menu_icon'       => 'dashicons-tickets-alt',
+			'menu_icon'       => SWH_ICON_1X,
 			'supports'        => array( 'title', 'editor' ),
 			'capability_type' => 'post',
 		)

--- a/simple-wp-helpdesk/includes/class-installer.php
+++ b/simple-wp-helpdesk/includes/class-installer.php
@@ -289,3 +289,16 @@ function swh_register_ticket_cpt() {
 		)
 	);
 }
+
+add_action( 'admin_head', 'swh_menu_icon_style' );
+/**
+ * Correct vertical alignment of the PNG menu icon.
+ *
+ * WordPress sets padding-top: 6px on .wp-menu-image img for SVG icons,
+ * which pushes PNG images too low. Reset it for our CPT menu item only.
+ *
+ * @return void
+ */
+function swh_menu_icon_style() {
+	echo '<style>#menu-posts-helpdesk_ticket .wp-menu-image img { padding-top: 0 !important; }</style>';
+}

--- a/testing/scripts/test_helpdesk.py
+++ b/testing/scripts/test_helpdesk.py
@@ -691,8 +691,55 @@ async def run():
         await wp_logout()
         await asyncio.sleep(0.5)
 
-        # ── [15] Cleanup ──────────────────────────────────────────────────────────
-        print("\n[15] Cleanup")
+        # ── [15] Plugin Icons ─────────────────────────────────────────────────────
+        print("\n[15] Plugin Icons")
+
+        CDN_BASE     = "https://media.seanmousseau.com/file/seanmousseau/assets/logos/swh"
+        CDN_ICON_128 = f"{CDN_BASE}/icon-128x128.png"
+        CDN_ICON_256 = f"{CDN_BASE}/icon-256x256.png"
+
+        # CDN reachability — use curl (hardcoded URLs, avoids dynamic urllib warning)
+        for cdn_url, label in ((CDN_ICON_128, "1x"), (CDN_ICON_256, "2x")):
+            result = subprocess.run(
+                ["curl", "-sI", "--max-time", "10", "-o", "/dev/null", "-w", "%{http_code}", cdn_url],
+                capture_output=True, text=True
+            )
+            check(f"plugin icon: CDN {label} image reachable", result.stdout.strip() == "200")
+
+        # PUC filter registered
+        filter_registered = wpcli(
+            "eval 'global $wp_filter; "
+            "echo isset($wp_filter[\"puc_request_info_result-simple-wp-helpdesk\"]) ? \"yes\" : \"no\";'"
+        )
+        check("plugin icon: puc_request_info_result filter registered", filter_registered == "yes")
+
+        # Filter returns correct icon URLs
+        icon_1x = wpcli(
+            "eval '"
+            "$info = (object)[]; "
+            "$result = apply_filters(\"puc_request_info_result-simple-wp-helpdesk\", $info); "
+            "echo $result->icons[\"1x\"] ?? \"\";'"
+        )
+        icon_2x = wpcli(
+            "eval '"
+            "$info = (object)[]; "
+            "$result = apply_filters(\"puc_request_info_result-simple-wp-helpdesk\", $info); "
+            "echo $result->icons[\"2x\"] ?? \"\";'"
+        )
+        check("plugin icon: puc filter returns correct 1x URL", icon_1x == CDN_ICON_128)
+        check("plugin icon: puc filter returns correct 2x URL", icon_2x == CDN_ICON_256)
+
+        # Icons injected into update transient
+        plugin_file = "simple-wp-helpdesk/simple-wp-helpdesk.php"
+        icon_in_transient = wpcli(
+            f"eval '$t = get_site_transient(\"update_plugins\"); "
+            f"$e = $t->response[\"{plugin_file}\"] ?? $t->no_update[\"{plugin_file}\"] ?? null; "
+            f"echo ($e && !empty($e->icons)) ? \"yes\" : \"no\";'"
+        )
+        check("plugin icon: icons injected into update transient", icon_in_transient == "yes")
+
+        # ── [16] Cleanup ──────────────────────────────────────────────────────────
+        print("\n[16] Cleanup")
 
         await wp_login(ADMIN_USER, ADMIN_PASS)
         await navigate(f"{WP_ADMIN_URL}/edit.php?post_type=helpdesk_ticket", wait=2.5)


### PR DESCRIPTION
## Summary

- Recovers three files that were missing after the squash merges of #177 and #178 — the merge commit only included `simple-wp-helpdesk.php`
- `class-installer.php`: use `SWH_MENU_ICON` (32×32 favicon) for CPT `menu_icon`; add `swh_menu_icon_style()` admin_head hook to fix PNG vertical alignment
- `class-settings.php`: add CDN-hosted icon to Settings page `<h2>` header
- `test_helpdesk.py`: add [15] Plugin Icons section with 7 CDP checks (CDN reachability, PUC filter, 1x/2x URL correctness, update transient injection); renumber Cleanup as [16]

## Test plan

- [x] Run full CDP test suite and confirm all checks pass including [15] Plugin Icons
- [x] Confirm admin menu shows 32×32 favicon icon with correct vertical alignment
- [x] Confirm Settings page header shows icon alongside "Helpdesk Settings" title

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added icon display to the settings page header.

* **Bug Fixes**
  * Fixed helpdesk ticket menu icon vertical alignment.

* **Tests**
  * Enhanced plugin icon verification in the testing suite with additional reachability checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->