### PR TITLE
chore: configure CodeRabbit and Semgrep

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,75 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: false
+
+reviews:
+  profile: "assertive"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+      - dev
+
+  path_filters:
+    - "!simple-wp-helpdesk/vendor/**"
+    - "!vendor/**"
+    - "!releases/**"
+    - "!testing/screenshots/**"
+    - "!testing/scripts/__pycache__/**"
+    - "!*.min.js"
+    - "!*.min.css"
+    - "!composer.lock"
+
+  path_instructions:
+    - path: "simple-wp-helpdesk/**/*.php"
+      instructions: |
+        This is a WordPress plugin (Simple WP Helpdesk). Review for:
+
+        Security:
+        - Nonce verification (wp_verify_nonce) on all form handlers
+        - Capability checks: manage_options for admin actions, edit_post for ticket saves
+        - All output escaped: esc_html(), esc_attr(), esc_url(), wp_kses_post()
+        - All input sanitized: sanitize_text_field(), sanitize_email(), absint(), etc.
+        - Token comparisons use hash_equals(), never == or ===
+        - File paths validated to start with the uploads directory
+        - Rate limiting via swh_get_client_ip(), never $_SERVER['REMOTE_ADDR'] directly
+
+        Conventions:
+        - All functions prefixed swh_, all classes prefixed SWH_
+        - New options must be registered in swh_get_defaults() in includes/helpers.php
+        - Email always sent via swh_send_email(), never wp_mail() directly
+        - helpdesk_reply comment type; internal notes use _is_internal_note meta
+        - No custom DB tables; uses CPT (helpdesk_ticket), post meta, wp_options, comments
+
+        Architecture:
+        - Bootstrap (simple-wp-helpdesk.php) stays thin
+        - Admin-only code stays in admin/ (gated by is_admin())
+        - New cron events registered in swh_activate(), cleared in swh_deactivate()
+        - Schema changes must bump version and add upgrade path in swh_run_upgrade_routine()
+
+    - path: "testing/**/*.py"
+      instructions: |
+        Playwright test suite for a WordPress plugin. Review for:
+        - Use check() soft-fail helper instead of hard asserts where appropriate
+        - State dict used for cross-section state (ticket_id, portal_url, etc.)
+        - _navigate_settings() called before clicking settings to remove WP pointer overlays
+        - Rate limits cleared with _clear_rate_limits() before security tests
+        - required attributes stripped via JS before validation test form submits
+        - wrap JS-triggered form submits in with page.expect_navigation()
+
+    - path: ".github/workflows/**"
+      instructions: |
+        GitHub Actions workflow. Review for:
+        - Pinned action versions (prefer full SHA or semver tags, not @main)
+        - Minimal permissions (principle of least privilege)
+        - Secrets referenced via ${{ secrets.NAME }}, never hardcoded
+
+chat:
+  auto_reply: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
-
-  - package-ecosystem: "composer"
-    directory: "/simple-wp-helpdesk/vendor/plugin-update-checker"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
+    allow:
+      - dependency-name: "phpstan/phpstan"
+      - dependency-name: "squizlabs/php_codesniffer"
+      - dependency-name: "phpunit/phpunit"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Semgrep
-        run: pip install semgrep
+        run: python -m pip install "semgrep==1.159.0"
 
       - name: Run Semgrep
         run: |
@@ -42,6 +42,6 @@ jobs:
 
       - name: Upload SARIF to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v3
-        if: always()
+        if: ${{ always() && hashFiles('semgrep.sarif') != '' }}
         with:
           sarif_file: semgrep.sarif

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,43 @@
+name: Semgrep Security Scan
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
+  schedule:
+    - cron: "0 6 * * 1" # Weekly, Monday 06:00 UTC
+
+jobs:
+  semgrep:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Semgrep
+        uses: semgrep/semgrep-action@v1
+        with:
+          config: >-
+            p/php
+            p/owasp-top-ten
+            p/security-audit
+          generateSarif: "1"
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+
+      - name: Upload SARIF to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: semgrep.sarif

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -25,14 +25,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install Semgrep
+        run: pip install semgrep
+
       - name: Run Semgrep
-        uses: semgrep/semgrep-action@v1
-        with:
-          config: >-
-            p/php
-            p/owasp-top-ten
-            p/security-audit
-          generateSarif: "1"
+        run: |
+          semgrep \
+            --config p/php \
+            --config p/owasp-top-ten \
+            --config p/security-audit \
+            --sarif \
+            --output semgrep.sarif \
+            .
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
 


### PR DESCRIPTION
## Summary

- **`.coderabbit.yaml`** — assertive review profile with PHP/WordPress-aware path instructions (security conventions, naming, architecture rules) and Playwright test guidance; excludes vendor, releases, screenshots, and lock files
- **`.github/workflows/semgrep.yml`** — runs `p/php`, `p/owasp-top-ten`, and `p/security-audit` rulesets on push/PR to `main`/`dev` and weekly on schedule; uploads SARIF to GitHub Code Scanning
- **`.github/dependabot.yml`** — narrows Composer scope to dev-only deps (phpstan, phpcs, phpunit); removes the `vendor/plugin-update-checker` entry (bundled library, not managed via Composer)

## Test plan

- [ ] Verify CodeRabbit posts a review on this PR
- [ ] Verify Semgrep workflow runs and passes (or surfaces real findings)
- [ ] Verify Dependabot no longer creates PRs for the PUC vendored library
- [ ] Verify SARIF results appear in GitHub Security → Code scanning alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated security scanning with scheduled scans and code-scan reporting.
  * Enhanced automated code review behavior and enabled chat auto-replies for PRs.
  * Updated dependency automation to restrict Composer updates to selected tooling packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->