### PR TITLE
fix: v3.4.1 — Makefile teardown, KPI transient bypass, portal theme setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ starting from the next release after 1.8.
 
 ---
 
+## [3.4.1] — 2026-04-20
+
+### Added
+
+- **Frontend Portal Theme setting (#327):** New option in Settings → General lets site owners choose between "Auto (follows system dark/light mode)" and "Force light mode". When set to light, outputs `data-swh-theme="light"` on `.swh-helpdesk-wrapper`, activating the v3.4.0 CSS escape hatch without requiring template edits.
+
+### Fixed
+
+- **`make e2e-docker` teardown (#325):** Trap now uses `$(CURDIR)/docker-compose.test.yml` (absolute path) so Docker containers are reliably torn down when `make` is invoked from the OneDrive alias working directory.
+- **KPI transient bypass (#326):** `swh_report_kpi_data()` now checks the `swh_report_avg_resolution_time` and `swh_report_first_response_time` transients before calling the sub-functions, eliminating redundant SQL queries on a KPI cache miss.
+
+---
+
 ## [3.4.0] — 2026-04-20
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,7 @@ Constants: `SWH_PLUGIN_DIR`, `SWH_PLUGIN_URL`, `SWH_PLUGIN_FILE` — use these i
 - **Dark mode tokens** — frontend only (`swh-shared.css` `@media (prefers-color-scheme: dark)` block). Do NOT add dark mode to `swh-admin.css` — WP admin handles its own colour schemes. Use `[data-swh-theme="light"]` escape hatch on `.swh-helpdesk-wrapper` for sites that control the theme themselves.
 - **Email HTML wrapper** — all CSS must be inlined. `swh_wrap_html_email()` in `class-email.php`. No `<link>` or `<style>` tags — email clients strip them.
 - **`swh_email_logo_url` option** — stored in `swh_options` via `swh_get_defaults()`; falls back to `get_site_icon_url(48)` if empty. Displayed at 32×32px in the email header band.
+- **`swh_portal_theme` option** — `'auto'` (default, follows `prefers-color-scheme`) or `'light'` (forces light mode). Output as `data-swh-theme="light"` attribute on every `.swh-helpdesk-wrapper` div in `class-portal.php` and `class-shortcode.php`. The CSS rule `.swh-helpdesk-wrapper[data-swh-theme="light"]` in `swh-shared.css` overrides the dark-mode media query.
 - **Ticket editor panel groups** — `.swh-panel-group` + `.swh-panel-group-label` in `class-ticket-editor.php`. Do NOT change form field `name` attributes or the save handler will break. IDs `#swh-status`, `#swh-priority`, `#swh-assigned-to` must remain.
 
 ## Release Process

--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,9 @@ e2e: ## Playwright E2E tests (requires WP environment — set WP_MODE=docker or 
 	@cd testing && source .venv/bin/activate && pytest scripts/test_helpdesk_pw.py -v
 
 e2e-docker: ## Full E2E in Docker — spin up stack, run suite, tear down
-	@trap 'docker compose -f docker-compose.test.yml down -v' EXIT; \
+	@trap 'docker compose -f $(CURDIR)/docker-compose.test.yml down -v' EXIT; \
 	 echo "→ Starting Docker stack..."; \
-	 docker compose -f docker-compose.test.yml up -d db wordpress wpcli mailhog; \
+	 docker compose -f $(CURDIR)/docker-compose.test.yml up -d db wordpress wpcli mailhog; \
 	 echo "→ Waiting for WordPress (up to 90s)..."; \
 	 i=0; until curl -sf http://localhost:8080/wp-login.php >/dev/null 2>&1; do \
 	   sleep 3; i=$$((i+3)); if [ $$i -ge 90 ]; then echo "ERROR: WordPress did not start in 90s"; exit 1; fi; \

--- a/simple-wp-helpdesk/admin/class-reporting.php
+++ b/simple-wp-helpdesk/admin/class-reporting.php
@@ -292,10 +292,12 @@ function swh_report_kpi_data() {
 	$cached_first_response = get_transient( 'swh_report_first_response_time' );
 	$first_response        = is_array( $cached_first_response ) ? $cached_first_response : swh_report_first_response_time();
 
+	$avg_res_raw  = $resolution['avg_seconds'] ?? null;
+	$avg_fres_raw = $first_response['avg_seconds'] ?? null;
 	return array(
 		'total'              => $total,
 		'open'               => $open,
-		'avg_resolution'     => $resolution['avg_seconds'],
-		'avg_first_response' => $first_response['avg_seconds'],
+		'avg_resolution'     => is_int( $avg_res_raw ) ? $avg_res_raw : 0,
+		'avg_first_response' => is_int( $avg_fres_raw ) ? $avg_fres_raw : 0,
 	);
 }

--- a/simple-wp-helpdesk/admin/class-reporting.php
+++ b/simple-wp-helpdesk/admin/class-reporting.php
@@ -14,7 +14,7 @@ add_action( 'wp_ajax_swh_report_data', 'swh_ajax_report_data' );
  * AJAX handler that returns reporting data as JSON.
  *
  * Accepts a `type` parameter: 'status_breakdown', 'avg_resolution_time',
- * 'weekly_trend', or 'first_response_time'. Results are cached in a 1-hour transient.
+ * 'weekly_trend', 'first_response_time', or 'kpi'. Results are cached in a 1-hour transient.
  *
  * @since 3.0.0
  * @return void

--- a/simple-wp-helpdesk/admin/class-reporting.php
+++ b/simple-wp-helpdesk/admin/class-reporting.php
@@ -287,10 +287,20 @@ function swh_report_kpi_data() {
 	) )->found_posts;
 
 	$cached_resolution = get_transient( 'swh_report_avg_resolution_time' );
-	$resolution        = is_array( $cached_resolution ) ? $cached_resolution : swh_report_avg_resolution_time();
+	if ( is_array( $cached_resolution ) ) {
+		$resolution = $cached_resolution;
+	} else {
+		$resolution = swh_report_avg_resolution_time();
+		set_transient( 'swh_report_avg_resolution_time', $resolution, HOUR_IN_SECONDS );
+	}
 
 	$cached_first_response = get_transient( 'swh_report_first_response_time' );
-	$first_response        = is_array( $cached_first_response ) ? $cached_first_response : swh_report_first_response_time();
+	if ( is_array( $cached_first_response ) ) {
+		$first_response = $cached_first_response;
+	} else {
+		$first_response = swh_report_first_response_time();
+		set_transient( 'swh_report_first_response_time', $first_response, HOUR_IN_SECONDS );
+	}
 
 	$avg_res_raw  = $resolution['avg_seconds'] ?? null;
 	$avg_fres_raw = $first_response['avg_seconds'] ?? null;

--- a/simple-wp-helpdesk/admin/class-reporting.php
+++ b/simple-wp-helpdesk/admin/class-reporting.php
@@ -286,8 +286,11 @@ function swh_report_kpi_data() {
 		)
 	) )->found_posts;
 
-	$resolution     = swh_report_avg_resolution_time();
-	$first_response = swh_report_first_response_time();
+	$cached_resolution = get_transient( 'swh_report_avg_resolution_time' );
+	$resolution        = is_array( $cached_resolution ) ? $cached_resolution : swh_report_avg_resolution_time();
+
+	$cached_first_response = get_transient( 'swh_report_first_response_time' );
+	$first_response        = is_array( $cached_first_response ) ? $cached_first_response : swh_report_first_response_time();
 
 	return array(
 		'total'              => $total,

--- a/simple-wp-helpdesk/admin/class-settings.php
+++ b/simple-wp-helpdesk/admin/class-settings.php
@@ -267,6 +267,9 @@ function swh_handle_settings_save() {
 				$val = is_string( $_POST[ $opt ] ) ? wp_kses_post( wp_unslash( $_POST[ $opt ] ) ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
 			} elseif ( 'swh_email_logo_url' === $opt ) {
 				$val = is_string( $_POST[ $opt ] ) ? esc_url_raw( wp_unslash( $_POST[ $opt ] ) ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+			} elseif ( 'swh_portal_theme' === $opt ) {
+				$raw = is_string( $_POST[ $opt ] ) ? sanitize_key( wp_unslash( $_POST[ $opt ] ) ) : 'auto'; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+				$val = in_array( $raw, array( 'auto', 'light' ), true ) ? $raw : 'auto';
 			} else {
 				$val = is_string( $_POST[ $opt ] ) ? sanitize_text_field( wp_unslash( $_POST[ $opt ] ) ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
 			}
@@ -468,6 +471,17 @@ function swh_render_settings_page() {
 						<input type="number" name="swh_token_expiration_days" value="<?php echo esc_attr( swh_get_string_option( 'swh_token_expiration_days', '90' ) ); ?>" style="width:80px;" min="0">
 						<?php esc_html_e( 'days (0 = never expires)', 'simple-wp-helpdesk' ); ?>
 						<p class="description"><?php esc_html_e( 'Ticket portal links expire after this many days. Clients can request fresh links via the lookup form.', 'simple-wp-helpdesk' ); ?></p>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><?php esc_html_e( 'Frontend Portal Theme', 'simple-wp-helpdesk' ); ?></th>
+					<td>
+						<?php $portal_theme = swh_get_string_option( 'swh_portal_theme', 'auto' ); ?>
+						<select name="swh_portal_theme">
+							<option value="auto" <?php selected( $portal_theme, 'auto' ); ?>><?php esc_html_e( 'Auto (follows system dark/light mode)', 'simple-wp-helpdesk' ); ?></option>
+							<option value="light" <?php selected( $portal_theme, 'light' ); ?>><?php esc_html_e( 'Force light mode', 'simple-wp-helpdesk' ); ?></option>
+						</select>
+						<p class="description"><?php esc_html_e( 'Controls whether the frontend helpdesk portal responds to the visitor\'s system dark/light mode preference. Set to "Force light mode" on sites that do not support dark mode.', 'simple-wp-helpdesk' ); ?></p>
 					</td>
 				</tr>
 				<tr>

--- a/simple-wp-helpdesk/frontend/class-portal.php
+++ b/simple-wp-helpdesk/frontend/class-portal.php
@@ -25,6 +25,7 @@ function swh_render_client_portal() {
 	$reopened_status = swh_get_string_option( 'swh_reopened_status', is_string( $defs['swh_reopened_status'] ) ? $defs['swh_reopened_status'] : '' );
 	$default_status  = swh_get_string_option( 'swh_default_status', is_string( $defs['swh_default_status'] ) ? $defs['swh_default_status'] : '' );
 	$spam_method     = swh_get_string_option( 'swh_spam_method', 'none' );
+	$theme_attr      = 'light' === swh_get_string_option( 'swh_portal_theme', 'auto' ) ? ' data-swh-theme="light"' : '';
 
 	// phpcs:disable WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotValidated -- Token-based auth; params verified via hash_equals() below; isset() checked by callers.
 	$ticket_id = isset( $_GET['swh_ticket'] ) && is_scalar( $_GET['swh_ticket'] ) ? absint( $_GET['swh_ticket'] ) : 0;
@@ -34,14 +35,14 @@ function swh_render_client_portal() {
 	$db_token = swh_get_string_meta( $ticket_id, '_ticket_token' );
 
 	if ( ! $post || 'helpdesk_ticket' !== $post->post_type || '' === $db_token || '' === $token || ! hash_equals( $db_token, $token ) ) {
-		echo '<div class="swh-helpdesk-wrapper">';
+		echo '<div class="swh-helpdesk-wrapper"' . $theme_attr . '>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded attribute string
 		echo '<div class="swh-alert swh-alert-error" role="alert">' . esc_html( swh_get_string_option( 'swh_msg_err_invalid', is_string( $defs['swh_msg_err_invalid'] ) ? $defs['swh_msg_err_invalid'] : '' ) ) . '</div>';
 		echo '</div>';
 		return;
 	}
 
 	if ( swh_is_token_expired( $ticket_id ) ) {
-		echo '<div class="swh-helpdesk-wrapper">';
+		echo '<div class="swh-helpdesk-wrapper"' . $theme_attr . '>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded attribute string
 		echo '<div class="swh-alert swh-alert-error" role="alert">' . esc_html( swh_get_string_option( 'swh_msg_err_expired', is_string( $defs['swh_msg_err_expired'] ) ? $defs['swh_msg_err_expired'] : '' ) ) . '</div>';
 		swh_render_lookup_form();
 		echo '</div>';
@@ -234,7 +235,7 @@ function swh_render_client_portal() {
 		} // end anti-spam else
 	}
 	?>
-	<div class="swh-helpdesk-wrapper">
+	<div class="swh-helpdesk-wrapper"<?php echo $theme_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded attribute string ?>>
 	<div class="swh-card">
 		<div style="float: right; font-weight: bold; color: #666; font-size: 1.2em;"><?php echo esc_html( $data['ticket_id'] ); ?></div>
 		<h1 class="swh-ticket-title"><?php echo esc_html( $data['title'] ); ?></h1>
@@ -410,7 +411,8 @@ function swh_render_client_portal() {
  * @return void
  */
 function swh_render_portal_no_token() {
-	echo '<div class="swh-helpdesk-wrapper">';
+	$theme_attr = 'light' === swh_get_string_option( 'swh_portal_theme', 'auto' ) ? ' data-swh-theme="light"' : '';
+	echo '<div class="swh-helpdesk-wrapper"' . $theme_attr . '>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded attribute string
 
 	if ( is_user_logged_in() ) {
 		$current_user  = wp_get_current_user();

--- a/simple-wp-helpdesk/frontend/class-shortcode.php
+++ b/simple-wp-helpdesk/frontend/class-shortcode.php
@@ -138,8 +138,9 @@ function swh_render_submission_form( $atts = array() ) {
 			);
 		}
 	}
+	$theme_attr = 'light' === swh_get_string_option( 'swh_portal_theme', 'auto' ) ? ' data-swh-theme="light"' : '';
 	?>
-	<div class="swh-helpdesk-wrapper">
+	<div class="swh-helpdesk-wrapper"<?php echo $theme_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- value is one of two hardcoded strings ?>>
 	<?php
 	$current_user = wp_get_current_user();
 	$form_name    = is_user_logged_in() ? ( is_string( $current_user->display_name ) ? $current_user->display_name : '' ) : '';

--- a/simple-wp-helpdesk/includes/helpers.php
+++ b/simple-wp-helpdesk/includes/helpers.php
@@ -113,6 +113,8 @@ function swh_get_defaults() {
 			// Email templates: ticket merge notification.
 			'swh_em_user_merged_sub'         => 'Your ticket has been merged: {ticket_id}',
 			'swh_em_user_merged_body'        => "Hi {name},\n\nYour ticket ({ticket_id}) has been merged into ticket {target_ticket_id}.\n\nYou can continue viewing your conversation here:\n{target_ticket_url}",
+			// Frontend portal appearance.
+			'swh_portal_theme'               => 'auto',
 		);
 	}
 	return $defaults;

--- a/simple-wp-helpdesk/readme.txt
+++ b/simple-wp-helpdesk/readme.txt
@@ -3,7 +3,7 @@ Contributors: seanmousseau
 Tags: helpdesk, tickets, support, customer service, ticketing
 Requires at least: 5.3
 Tested up to: 6.7
-Stable tag: 3.4.0
+Stable tag: 3.4.1
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -73,6 +73,11 @@ Yes. Enable "Restrict Technicians" in Settings > Assignment & Routing. Technicia
 5. Settings page — Email Templates tab
 
 == Changelog ==
+
+= 3.4.1 =
+* Added: Frontend Portal Theme setting — "Force light mode" option pins portal to light mode on sites without dark mode support (#327)
+* Fixed: `make e2e-docker` teardown trap now uses absolute path via `$(CURDIR)` so Docker containers reliably stop when make is run from an OneDrive alias path (#325)
+* Fixed: Reporting KPI endpoint now checks individual sub-function transients before running SQL, eliminating redundant queries on a KPI cache miss (#326)
 
 = 3.4.0 =
 * Added: Frontend dark mode via `prefers-color-scheme: dark` token overrides in `swh-shared.css`; escape hatch via `[data-swh-theme="light"]` (#321)

--- a/simple-wp-helpdesk/simple-wp-helpdesk.php
+++ b/simple-wp-helpdesk/simple-wp-helpdesk.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Simple WP Helpdesk
  * Description: A comprehensive helpdesk system with auto-close, custom templates, multi-file attachments, internal notes, anti-spam, deep uninstallation cleanup, and GitHub auto-updates.
- * Version: 3.4.0
+ * Version: 3.4.1
  * Requires at least: 5.3
  * Requires PHP: 7.4
  * Text Domain: simple-wp-helpdesk
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWH_VERSION', '3.4.0' );
+define( 'SWH_VERSION', '3.4.1' );
 define( 'SWH_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWH_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWH_PLUGIN_FILE', __FILE__ );


### PR DESCRIPTION
## Summary

- **#325** — `make e2e-docker` trap now uses `$(CURDIR)/docker-compose.test.yml` so Docker containers tear down reliably when `make` is run from the OneDrive alias working directory
- **#326** — `swh_report_kpi_data()` now checks `swh_report_avg_resolution_time` and `swh_report_first_response_time` transients before running SQL, eliminating redundant queries on a KPI cache miss
- **#327** — New **Frontend Portal Theme** setting (Settings → General) — "Auto (follows system dark/light mode)" or "Force light mode". Outputs `data-swh-theme="light"` on `.swh-helpdesk-wrapper`, activating the v3.4.0 CSS escape hatch

Closes #325, #326, #327

## Test plan

- [x] `make test-docker` — lint, PHPCS, PHPStan level 9, PHPUnit 52/52, Semgrep all green
- [x] `make e2e-docker` — 54/54 sections passed in 2:04; Docker containers torn down cleanly after run (trap fix verified)
- [ ] CodeRabbit `/review`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Frontend Portal Theme setting (Settings → General) with "auto" and "light" options to force a light-mode portal UI.

* **Bug Fixes**
  * More reliable Docker-based test environment teardown using absolute paths.
  * KPI reporting reduced redundant database work on cache misses by better cache checks.

* **Documentation**
  * Changelog, plugin metadata, and version updated to 3.4.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->