### PR TITLE
feat: v3.5.0 — Consistency & Feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ testing/screenshots/
 
 # Remember plugin (session memory, generated at runtime)
 .remember/
+
+# Git worktrees
+.worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ starting from the next release after 1.8.
 ### Changed
 
 - **`swh-frontend.css`:** Duplicate `.swh-badge` block removed — styles now inherited from `swh-shared.css`.
+- **Dev:** Pinned `doctrine/instantiator` to `^1.5` in `composer.json` to maintain PHP 8.2 compatibility (2.1.0 requires PHP ≥ 8.4).
 
 ---
 
@@ -524,7 +525,10 @@ starting from the next release after 1.8.
 
 ---
 
-[Unreleased]: https://github.com/seanmousseau/Simple-WP-Helpdesk/compare/v3.3.0...HEAD
+[Unreleased]: https://github.com/seanmousseau/Simple-WP-Helpdesk/compare/v3.5.0...HEAD
+[3.5.0]: https://github.com/seanmousseau/Simple-WP-Helpdesk/compare/v3.4.1...v3.5.0
+[3.4.1]: https://github.com/seanmousseau/Simple-WP-Helpdesk/compare/v3.4.0...v3.4.1
+[3.4.0]: https://github.com/seanmousseau/Simple-WP-Helpdesk/compare/v3.3.0...v3.4.0
 [3.3.0]: https://github.com/seanmousseau/Simple-WP-Helpdesk/compare/v3.2.0...v3.3.0
 [3.2.0]: https://github.com/seanmousseau/Simple-WP-Helpdesk/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/seanmousseau/Simple-WP-Helpdesk/compare/v3.0.0...v3.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ starting from the next release after 1.8.
 
 ---
 
+## [3.5.0] — 2026-04-23
+
+### Added
+
+- **Unified badge system (#329, #330):** Single `.swh-badge` base class and `.swh-badge-{slug}` modifier classes defined in `swh-shared.css`. All admin and editor badge rendering now uses `sanitize_title($status)` → CSS modifier, eliminating hardcoded hex colours.
+- **Design token scales (#331):** Shadow (`--swh-shadow-sm/md/lg`), z-index (`--swh-z-base/dropdown/modal/toast`), and easing (`--swh-ease-out/in-out`) token scales added to `swh-shared.css`.
+- **Toast notification component (#333):** Reusable `swhToast(message, type, duration)` JS function and `.swh-toast` CSS component added to `swh-admin.js` / `swh-admin.css`. Auto-dismisses after 4 s; accessible dismiss button; three variants (success/error/info).
+- **Settings save toast (#334):** Settings save now shows a toast notification instead of the legacy WP admin notice. URL param cleaned via `history.replaceState()` to prevent re-trigger on refresh.
+- **Reports skeleton loaders (#332):** KPI cards and chart canvases display shimmer skeleton placeholders while AJAX fetches are in flight.
+- **`aria-busy` coverage (#335):** KPI grid and chart cards expose `aria-busy="true"` during loading and `aria-busy="false"` once data has populated.
+- **Focus return on error (#336):** `swh-frontend.js` now focuses the first `.swh-alert-error` element on DOMContentLoaded so screen-reader and keyboard users land on the error message immediately.
+- **Interactive hover feedback (#337):** Admin ticket list rows gain a background-colour hover transition; row action links and badges gain visible focus rings.
+- **`prefers-reduced-motion` safeguard (#337):** Global `@media (prefers-reduced-motion: reduce)` block in `swh-shared.css` suppresses all animations and transitions for users who have opted in to reduced motion.
+- **E2E tests for v3.5.0 UX (sections 57–58):** Section 57 covers toast appearance, auto-dismiss, and × button; section 58 covers Reports page skeleton loaders and `aria-busy` state.
+
+### Changed
+
+- **`swh-frontend.css`:** Duplicate `.swh-badge` block removed — styles now inherited from `swh-shared.css`.
+
+---
+
 ## [3.4.1] — 2026-04-20
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
         "wp-coding-standards/wpcs": "^3.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
         "phpunit/phpunit": "^9.6",
-        "10up/wp_mock": "^1.0"
+        "10up/wp_mock": "^1.0",
+        "doctrine/instantiator": "^1.5"
     },
     "config": {
         "allow-plugins": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -141,3 +141,21 @@ Check **Delete all plugin data on uninstall** to permanently remove all tickets,
 | **Purge All Tickets** | Permanently deletes every ticket and its attachments |
 | **GDPR Email Purge** | Deletes all tickets, replies, and files associated with a specific email address |
 | **Factory Reset** | Resets all settings to defaults; does not delete tickets |
+
+---
+
+## UX Feedback
+
+### Toast Notifications
+
+After saving settings, a toast notification slides in from the bottom-right corner confirming the save. It auto-dismisses after ~4 seconds and can be closed immediately with the **×** button.
+
+Toast notifications are built on `swhToast(message, type, duration)` in `swh-admin.js`. The function is available globally on any page that loads `swh-admin.js`.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `message` | string | — | Text to display |
+| `type` | `'success'` \| `'error'` \| `'info'` | `'success'` | Visual variant |
+| `duration` | number | `4000` | Auto-dismiss delay in ms |
+
+The `?swh_notice=saved` redirect query parameter triggers the toast on page load. The parameter is removed from the URL via `history.replaceState()` so a page refresh does not re-trigger the notification.

--- a/docs/development.md
+++ b/docs/development.md
@@ -155,6 +155,66 @@ Individual tools:
 
 ---
 
+## Design Tokens
+
+CSS custom properties (design tokens) are defined in `swh-shared.css`, which is loaded as a dependency of both `swh-admin.css` and `swh-frontend.css`. All tokens use the `--swh-` prefix.
+
+### Token Scales (v3.5.0)
+
+**Shadow scale**
+
+| Token | Value |
+|-------|-------|
+| `--swh-shadow-sm` | `0 1px 2px rgba(0,0,0,0.08)` |
+| `--swh-shadow-md` | `0 2px 6px rgba(0,0,0,0.12)` |
+| `--swh-shadow-lg` | `0 4px 12px rgba(0,0,0,0.16)` |
+
+**Z-index scale**
+
+| Token | Value | Used by |
+|-------|-------|---------|
+| `--swh-z-base` | `1` | General stacking |
+| `--swh-z-dropdown` | `100` | Dropdowns, popovers |
+| `--swh-z-modal` | `200` | Modal dialogs |
+| `--swh-z-toast` | `300` | Toast notifications |
+
+**Easing**
+
+| Token | Value |
+|-------|-------|
+| `--swh-ease-out` | `cubic-bezier(0,0,0.2,1)` |
+| `--swh-ease-in-out` | `cubic-bezier(0.4,0,0.2,1)` |
+
+---
+
+## Badge System
+
+All status badges use a unified CSS component defined in `swh-shared.css`.
+
+**Base class:** `.swh-badge` — inline-block pill with padding, border-radius, and a hover transition.
+
+**Modifier classes:** `.swh-badge-{slug}` where `slug = sanitize_title($status)`.
+
+| Class | Used for |
+|-------|---------|
+| `.swh-badge-open` | Open tickets |
+| `.swh-badge-in-progress` | In Progress tickets |
+| `.swh-badge-resolved` | Resolved tickets |
+| `.swh-badge-closed` | Closed tickets |
+| `.swh-badge-sla-warn` | SLA warning state |
+| `.swh-badge-sla-breach` | SLA breach state |
+
+**PHP pattern** (in admin list / editor):
+```php
+$status_slug = sanitize_title( $status );
+echo '<span class="swh-badge swh-badge-' . esc_attr( $status_slug ) . '">'
+     . esc_html( $status ) . '</span>';
+```
+
+Adding a new status automatically gets a badge modifier if a `.swh-badge-{slug}` rule exists in `swh-shared.css`. For unknown slugs the base `.swh-badge` styles still apply (neutral appearance).
+
+---
+
 ## Release Process
 
 1. **Bump the version** in `simple-wp-helpdesk.php`:

--- a/docs/development.md
+++ b/docs/development.md
@@ -205,13 +205,14 @@ All status badges use a unified CSS component defined in `swh-shared.css`.
 | `.swh-badge-sla-breach` | SLA breach state |
 
 **PHP pattern** (in admin list / editor):
+
 ```php
 $status_slug = sanitize_title( $status );
 echo '<span class="swh-badge swh-badge-' . esc_attr( $status_slug ) . '">'
      . esc_html( $status ) . '</span>';
 ```
 
-Adding a new status automatically gets a badge modifier if a `.swh-badge-{slug}` rule exists in `swh-shared.css`. For unknown slugs the base `.swh-badge` styles still apply (neutral appearance).
+Adding a new status automatically gets a badge modifier if a `.swh-badge-{slug}` rule exists in `swh-shared.css`. For unknown slugs only the base `.swh-badge` shape and spacing apply — no background colour or text colour is set, so those inherit from the parent context.
 
 ---
 

--- a/simple-wp-helpdesk/admin/class-reporting-ui.php
+++ b/simple-wp-helpdesk/admin/class-reporting-ui.php
@@ -78,37 +78,43 @@ function swh_render_reports_page() {
 	?>
 	<div class="wrap">
 		<h1><?php esc_html_e( 'Helpdesk Reports', 'simple-wp-helpdesk' ); ?></h1>
-		<div class="swh-kpi-grid" aria-label="<?php esc_attr_e( 'Key performance indicators', 'simple-wp-helpdesk' ); ?>">
+		<div class="swh-kpi-grid" id="swh-kpi-grid" aria-label="<?php esc_attr_e( 'Key performance indicators', 'simple-wp-helpdesk' ); ?>" aria-busy="true">
 			<div class="swh-kpi-card">
 				<svg class="swh-kpi-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 4H4C2.9 4 2 4.9 2 6v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4v-6h16v6zM4 8V6h16v2H4z"/></svg>
-				<p class="swh-kpi-value" id="swh-kpi-total">&mdash;</p>
+				<div class="swh-skeleton swh-kpi-skeleton" id="swh-kpi-total-skeleton" aria-hidden="true"></div>
+				<p class="swh-kpi-value" id="swh-kpi-total" hidden>&mdash;</p>
 				<p class="swh-kpi-label"><?php esc_html_e( 'Total Tickets', 'simple-wp-helpdesk' ); ?></p>
 			</div>
 			<div class="swh-kpi-card swh-kpi-card--warning">
 				<svg class="swh-kpi-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 15v-4H7l5-8v4h4l-5 8z"/></svg>
-				<p class="swh-kpi-value" id="swh-kpi-open">&mdash;</p>
+				<div class="swh-skeleton swh-kpi-skeleton" id="swh-kpi-open-skeleton" aria-hidden="true"></div>
+				<p class="swh-kpi-value" id="swh-kpi-open" hidden>&mdash;</p>
 				<p class="swh-kpi-label"><?php esc_html_e( 'Open Tickets', 'simple-wp-helpdesk' ); ?></p>
 			</div>
 			<div class="swh-kpi-card swh-kpi-card--success">
 				<svg class="swh-kpi-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2a10 10 0 1 0 0 20A10 10 0 0 0 12 2zm.75 14.5h-1.5V11h1.5v5.5zm0-7h-1.5V8h1.5v1.5z"/></svg>
-				<p class="swh-kpi-value" id="swh-kpi-resolution">&mdash;</p>
+				<div class="swh-skeleton swh-kpi-skeleton" id="swh-kpi-resolution-skeleton" aria-hidden="true"></div>
+				<p class="swh-kpi-value" id="swh-kpi-resolution" hidden>&mdash;</p>
 				<p class="swh-kpi-label"><?php esc_html_e( 'Avg. Resolution (30d)', 'simple-wp-helpdesk' ); ?></p>
 			</div>
 			<div class="swh-kpi-card swh-kpi-card--success">
 				<svg class="swh-kpi-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2z"/></svg>
-				<p class="swh-kpi-value" id="swh-kpi-first-response">&mdash;</p>
+				<div class="swh-skeleton swh-kpi-skeleton" id="swh-kpi-first-response-skeleton" aria-hidden="true"></div>
+				<p class="swh-kpi-value" id="swh-kpi-first-response" hidden>&mdash;</p>
 				<p class="swh-kpi-label"><?php esc_html_e( 'Avg. First Response (30d)', 'simple-wp-helpdesk' ); ?></p>
 			</div>
 		</div>
 		<div class="swh-report-grid">
-			<div class="swh-report-card">
+			<div class="swh-report-card" id="swh-report-card-status" aria-busy="true">
 				<h2><?php esc_html_e( 'Tickets by Status', 'simple-wp-helpdesk' ); ?></h2>
-				<canvas id="swh-chart-status" height="200"></canvas>
+				<div class="swh-skeleton swh-chart-skeleton" id="swh-chart-status-skeleton" aria-hidden="true"></div>
+				<canvas id="swh-chart-status" height="200" hidden></canvas>
 				<p id="swh-chart-status-empty" class="swh-chart-empty" hidden><?php esc_html_e( 'No ticket data yet.', 'simple-wp-helpdesk' ); ?></p>
 			</div>
-			<div class="swh-report-card">
+			<div class="swh-report-card" id="swh-report-card-trend" aria-busy="true">
 				<h2><?php esc_html_e( 'Weekly Trend (8 Weeks)', 'simple-wp-helpdesk' ); ?></h2>
-				<canvas id="swh-chart-trend" height="200"></canvas>
+				<div class="swh-skeleton swh-chart-skeleton" id="swh-chart-trend-skeleton" aria-hidden="true"></div>
+				<canvas id="swh-chart-trend" height="200" hidden></canvas>
 				<p id="swh-chart-trend-empty" class="swh-chart-empty" hidden><?php esc_html_e( 'No ticket data yet.', 'simple-wp-helpdesk' ); ?></p>
 			</div>
 			<div class="swh-report-card">

--- a/simple-wp-helpdesk/admin/class-settings.php
+++ b/simple-wp-helpdesk/admin/class-settings.php
@@ -83,6 +83,8 @@ function swh_enqueue_admin_assets( $hook ) {
 				'testEmailNetworkError'  => __( 'Network error. Please try again.', 'simple-wp-helpdesk' ),
 				/* translators: Accessible label for the dismiss button on a toast notification. */
 				'dismissNotification'    => __( 'Dismiss notification', 'simple-wp-helpdesk' ),
+				/* translators: Brief success message shown in a toast after settings are saved. */
+				'settingsSaved'          => __( 'Settings saved successfully.', 'simple-wp-helpdesk' ),
 			),
 		)
 	);
@@ -362,9 +364,8 @@ function swh_render_settings_page() {
 	// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Read-only GET params set by server redirect; used only for display.
 	if ( isset( $_GET['swh_notice'] ) ) {
 		$notice = sanitize_key( is_string( $_GET['swh_notice'] ) ? $_GET['swh_notice'] : '' );
-		if ( 'saved' === $notice ) {
-			echo '<div class="updated notice is-dismissible"><p><strong>' . esc_html__( 'Settings saved successfully.', 'simple-wp-helpdesk' ) . '</strong></p></div>';
-		} elseif ( 'reset' === $notice ) {
+		// 'saved' notice is handled by swhToast() in swh-admin.js (#334); no server-side notice needed.
+		if ( 'reset' === $notice ) {
 			echo '<div class="updated error notice is-dismissible"><p><strong>' . esc_html__( 'Plugin Factory Reset Complete. All tickets/files purged and settings reverted to default.', 'simple-wp-helpdesk' ) . '</strong></p></div>';
 		} elseif ( 'purged' === $notice ) {
 			echo '<div class="updated error notice is-dismissible"><p><strong>' . esc_html__( 'All tickets & files have been successfully purged.', 'simple-wp-helpdesk' ) . '</strong></p></div>';

--- a/simple-wp-helpdesk/admin/class-settings.php
+++ b/simple-wp-helpdesk/admin/class-settings.php
@@ -81,6 +81,8 @@ function swh_enqueue_admin_assets( $hook ) {
 				'testEmailSuccess'       => __( 'Test email sent successfully.', 'simple-wp-helpdesk' ),
 				'testEmailError'         => __( 'Failed to send test email.', 'simple-wp-helpdesk' ),
 				'testEmailNetworkError'  => __( 'Network error. Please try again.', 'simple-wp-helpdesk' ),
+				/* translators: Accessible label for the dismiss button on a toast notification. */
+				'dismissNotification'    => __( 'Dismiss notification', 'simple-wp-helpdesk' ),
 			),
 		)
 	);

--- a/simple-wp-helpdesk/admin/class-ticket-editor.php
+++ b/simple-wp-helpdesk/admin/class-ticket-editor.php
@@ -178,10 +178,10 @@ function swh_status_meta_box_html( $post ) {
 			</select>
 			<?php if ( $sla_status ) : ?>
 				<?php
-				$sla_bg    = 'breach' === $sla_status ? '#d63638' : '#dba617';
+				$sla_class = 'breach' === $sla_status ? 'swh-badge-sla-breach' : 'swh-badge-sla-warn';
 				$sla_label = 'breach' === $sla_status ? __( 'SLA Breach', 'simple-wp-helpdesk' ) : __( 'SLA Warning', 'simple-wp-helpdesk' );
 				?>
-				<div style="margin-top:8px; padding:6px 10px; background:<?php echo esc_attr( $sla_bg ); ?>; color:#fff; border-radius:3px; font-weight:bold; font-size:12px;"><?php echo esc_html( $sla_label ); ?></div>
+				<div class="swh-badge <?php echo esc_attr( $sla_class ); ?>" style="margin-top:8px;"><?php echo esc_html( $sla_label ); ?></div>
 			<?php endif; ?>
 		</div>
 

--- a/simple-wp-helpdesk/admin/class-ticket-editor.php
+++ b/simple-wp-helpdesk/admin/class-ticket-editor.php
@@ -181,7 +181,7 @@ function swh_status_meta_box_html( $post ) {
 				$sla_class = 'breach' === $sla_status ? 'swh-badge-sla-breach' : 'swh-badge-sla-warn';
 				$sla_label = 'breach' === $sla_status ? __( 'SLA Breach', 'simple-wp-helpdesk' ) : __( 'SLA Warning', 'simple-wp-helpdesk' );
 				?>
-				<div class="swh-badge <?php echo esc_attr( $sla_class ); ?>" style="margin-top:8px;"><?php echo esc_html( $sla_label ); ?></div>
+				<div class="swh-sla-badge-wrap"><span class="swh-badge <?php echo esc_attr( $sla_class ); ?>"><?php echo esc_html( $sla_label ); ?></span></div>
 			<?php endif; ?>
 		</div>
 

--- a/simple-wp-helpdesk/admin/class-ticket-list.php
+++ b/simple-wp-helpdesk/admin/class-ticket-list.php
@@ -124,30 +124,15 @@ add_action( 'manage_helpdesk_ticket_posts_custom_column', 'swh_ticket_column_con
  * @return void
  */
 function swh_ticket_column_content( $column, $post_id ) {
-	$defs = swh_get_defaults();
 	switch ( $column ) {
 		case 'ticket_uid':
 			$uid = swh_get_string_meta( $post_id, '_ticket_uid' );
 			echo esc_html( $uid ? $uid : '—' );
 			break;
 		case 'ticket_status':
-			$status          = swh_get_string_meta( $post_id, '_ticket_status' );
-			$closed_status   = swh_get_string_option( 'swh_closed_status', is_string( $defs['swh_closed_status'] ) ? $defs['swh_closed_status'] : '' );
-			$resolved_status = swh_get_string_option( 'swh_resolved_status', is_string( $defs['swh_resolved_status'] ) ? $defs['swh_resolved_status'] : '' );
-			if ( $status === $closed_status ) {
-				$bg    = '#f8d7da';
-				$color = '#721c24';
-			} elseif ( $status === $resolved_status ) {
-				$bg    = '#e6f7ff';
-				$color = '#005980';
-			} elseif ( stripos( $status, 'progress' ) !== false ) {
-				$bg    = '#fff3cd';
-				$color = '#856404';
-			} else {
-				$bg    = '#d4edda';
-				$color = '#155724';
-			}
-			echo '<span class="swh-status-badge" style="background:' . esc_attr( $bg ) . ';color:' . esc_attr( $color ) . ';">' . esc_html( $status ) . '</span>';
+			$status      = swh_get_string_meta( $post_id, '_ticket_status' );
+			$status_slug = sanitize_title( $status );
+			echo '<span class="swh-badge swh-badge-' . esc_attr( $status_slug ) . '">' . esc_html( $status ) . '</span>';
 			break;
 		case 'ticket_priority':
 			$priority = swh_get_string_meta( $post_id, '_ticket_priority' );
@@ -159,7 +144,7 @@ function swh_ticket_column_content( $column, $post_id ) {
 				$user = get_userdata( $assigned );
 				echo $user ? esc_html( is_string( $user->display_name ) ? $user->display_name : '' ) : esc_html__( 'Unknown', 'simple-wp-helpdesk' );
 			} else {
-				echo '<span style="color:#999;">' . esc_html__( 'Unassigned', 'simple-wp-helpdesk' ) . '</span>';
+				echo '<span class="swh-text-muted">' . esc_html__( 'Unassigned', 'simple-wp-helpdesk' ) . '</span>';
 			}
 			break;
 		case 'ticket_client':
@@ -169,7 +154,7 @@ function swh_ticket_column_content( $column, $post_id ) {
 				echo esc_html( $name );
 			}
 			if ( $email ) {
-				echo '<br><small style="color:#666;">' . esc_html( $email ) . '</small>';
+				echo '<br><small class="swh-text-secondary">' . esc_html( $email ) . '</small>';
 			}
 			if ( ! $name && ! $email ) {
 				echo '—';

--- a/simple-wp-helpdesk/assets/swh-admin.css
+++ b/simple-wp-helpdesk/assets/swh-admin.css
@@ -1,15 +1,5 @@
 /* Design tokens are defined in swh-shared.css (loaded as a dependency). */
 
-/* #259: Pill-style status badges */
-.swh-status-badge {
-	display: inline-block;
-	padding: 3px 10px;
-	border-radius: var( --swh-radius-pill );
-	font-size: var( --swh-font-sm );
-	font-weight: 600;
-	white-space: nowrap;
-	letter-spacing: 0.02em;
-}
 
 .column-ticket_uid {
 	width: 100px;
@@ -390,3 +380,7 @@ th[aria-sort="descending"] .sorting-indicator::after { content: " ▼"; font-siz
 	margin-left: 4px;
 	vertical-align: middle;
 }
+
+/* ── Text utility classes (#329) ────────────────────────────────────────── */
+.swh-text-muted     { color: var( --swh-color-muted ); }
+.swh-text-secondary { color: var( --swh-color-text-secondary ); }

--- a/simple-wp-helpdesk/assets/swh-admin.css
+++ b/simple-wp-helpdesk/assets/swh-admin.css
@@ -403,3 +403,35 @@ th[aria-sort="descending"] .sorting-indicator::after { content: " ▼"; font-siz
 	outline-offset: 2px;
 	border-radius: var( --swh-radius-sm );
 }
+
+/* ── Skeleton loader (#332) ──────────────────────────────────────────────── */
+@keyframes swh-shimmer {
+	0%   { background-position: -400px 0; }
+	100% { background-position:  400px 0; }
+}
+
+.swh-skeleton {
+	background: linear-gradient(
+		90deg,
+		var( --swh-color-surface ) 25%,
+		var( --swh-color-bg-subtle ) 50%,
+		var( --swh-color-surface ) 75%
+	);
+	background-size: 800px 100%;
+	animation: swh-shimmer 1.4s ease-in-out infinite;
+	border-radius: var( --swh-radius-sm );
+	color: transparent;
+	pointer-events: none;
+	user-select: none;
+}
+
+.swh-kpi-skeleton {
+	height: 2rem;
+	width: 60%;
+	margin: var( --swh-space-sm ) auto;
+}
+
+.swh-chart-skeleton {
+	height: 200px;
+	width: 100%;
+}

--- a/simple-wp-helpdesk/assets/swh-admin.css
+++ b/simple-wp-helpdesk/assets/swh-admin.css
@@ -435,3 +435,64 @@ th[aria-sort="descending"] .sorting-indicator::after { content: " ▼"; font-siz
 	height: 200px;
 	width: 100%;
 }
+
+/* ── Toast notification (#333) ───────────────────────────────────────────── */
+.swh-toast {
+	position: fixed;
+	bottom: var( --swh-space-lg );
+	right: var( --swh-space-lg );
+	z-index: var( --swh-z-toast );
+	display: flex;
+	align-items: center;
+	gap: var( --swh-space-sm );
+	padding: var( --swh-space-sm ) var( --swh-space-md );
+	background: var( --swh-color-surface );
+	border: 1px solid var( --swh-color-border );
+	border-radius: var( --swh-radius-md );
+	box-shadow: var( --swh-shadow-md );
+	max-width: 360px;
+	font-size: 13px;
+	line-height: 1.4;
+	opacity: 0;
+	transform: translateY( 8px );
+	transition:
+		opacity var( --swh-transition-normal ) var( --swh-ease-out ),
+		transform var( --swh-transition-normal ) var( --swh-ease-out );
+	pointer-events: none;
+}
+
+.swh-toast.swh-toast--visible {
+	opacity: 1;
+	transform: translateY( 0 );
+	pointer-events: auto;
+}
+
+.swh-toast--success { border-left: 3px solid var( --swh-color-success ); }
+.swh-toast--error   { border-left: 3px solid var( --swh-color-danger ); }
+.swh-toast--info    { border-left: 3px solid var( --swh-color-primary ); }
+
+.swh-toast__message {
+	flex: 1;
+	color: var( --swh-color-text );
+}
+
+.swh-toast__dismiss {
+	flex-shrink: 0;
+	background: none;
+	border: none;
+	cursor: pointer;
+	color: var( --swh-color-text-muted );
+	font-size: 16px;
+	line-height: 1;
+	padding: 2px 4px;
+	border-radius: var( --swh-radius-sm );
+}
+
+.swh-toast__dismiss:hover {
+	color: var( --swh-color-text );
+}
+
+.swh-toast__dismiss:focus-visible {
+	outline: 2px solid var( --swh-color-focus );
+	outline-offset: 2px;
+}

--- a/simple-wp-helpdesk/assets/swh-admin.css
+++ b/simple-wp-helpdesk/assets/swh-admin.css
@@ -389,7 +389,7 @@ th[aria-sort="descending"] .sorting-indicator::after { content: " ▼"; font-siz
 .swh-sla-badge-wrap { margin-top: var( --swh-space-xs ); }
 
 /* ── Ticket list row hover feedback (#337) ───────────────────────────────── */
-#the-list tr {
+#the-list tr td {
 	transition: background-color var( --swh-transition-fast ) var( --swh-ease-out );
 }
 
@@ -467,7 +467,7 @@ th[aria-sort="descending"] .sorting-indicator::after { content: " ▼"; font-siz
 	pointer-events: auto;
 }
 
-.swh-toast--success { border-left: 3px solid var( --swh-color-success ); }
+.swh-toast--success { border-left: 3px solid var( --swh-color-success-accent ); }
 .swh-toast--error   { border-left: 3px solid var( --swh-color-danger ); }
 .swh-toast--info    { border-left: 3px solid var( --swh-color-primary ); }
 

--- a/simple-wp-helpdesk/assets/swh-admin.css
+++ b/simple-wp-helpdesk/assets/swh-admin.css
@@ -481,7 +481,7 @@ th[aria-sort="descending"] .sorting-indicator::after { content: " ▼"; font-siz
 	background: none;
 	border: none;
 	cursor: pointer;
-	color: var( --swh-color-text-muted );
+	color: var( --swh-color-muted );
 	font-size: 16px;
 	line-height: 1;
 	padding: 2px 4px;

--- a/simple-wp-helpdesk/assets/swh-admin.css
+++ b/simple-wp-helpdesk/assets/swh-admin.css
@@ -387,3 +387,19 @@ th[aria-sort="descending"] .sorting-indicator::after { content: " ▼"; font-siz
 
 /* SLA badge in ticket editor panel */
 .swh-sla-badge-wrap { margin-top: var( --swh-space-xs ); }
+
+/* ── Ticket list row hover feedback (#337) ───────────────────────────────── */
+#the-list tr {
+	transition: background-color var( --swh-transition-fast ) var( --swh-ease-out );
+}
+
+#the-list tr:hover td {
+	background-color: var( --swh-color-bg-highlight );
+}
+
+.row-actions a:focus-visible,
+.swh-badge:focus-visible {
+	outline: 2px solid var( --swh-color-focus );
+	outline-offset: 2px;
+	border-radius: var( --swh-radius-sm );
+}

--- a/simple-wp-helpdesk/assets/swh-admin.css
+++ b/simple-wp-helpdesk/assets/swh-admin.css
@@ -384,3 +384,6 @@ th[aria-sort="descending"] .sorting-indicator::after { content: " ▼"; font-siz
 /* ── Text utility classes (#329) ────────────────────────────────────────── */
 .swh-text-muted     { color: var( --swh-color-muted ); }
 .swh-text-secondary { color: var( --swh-color-text-secondary ); }
+
+/* SLA badge in ticket editor panel */
+.swh-sla-badge-wrap { margin-top: var( --swh-space-xs ); }

--- a/simple-wp-helpdesk/assets/swh-admin.js
+++ b/simple-wp-helpdesk/assets/swh-admin.js
@@ -101,6 +101,18 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		activateTab( restoreTab );
 	}
 
+	// Settings save toast — triggered by redirect query param (#334).
+	if ( urlParams.get( 'swh_notice' ) === 'saved' ) {
+		var savedMsg = ( typeof swhAdmin !== 'undefined' && swhAdmin.i18n && swhAdmin.i18n.settingsSaved )
+			? swhAdmin.i18n.settingsSaved
+			: 'Settings saved.';
+		swhToast( savedMsg, 'success' );
+		var cleanSearch = window.location.search
+			.replace( /([?&])swh_notice=saved(&|$)/, function ( _m, pre, suf ) { return suf ? pre : ''; } )
+			.replace( /^&/, '?' );
+		history.replaceState( null, '', window.location.pathname + cleanSearch + window.location.hash );
+	}
+
 	/**
 	 * Handles tab click events to switch the active settings panel.
 	 *

--- a/simple-wp-helpdesk/assets/swh-admin.js
+++ b/simple-wp-helpdesk/assets/swh-admin.js
@@ -19,7 +19,8 @@
  * @param {number} [duration=4000] - Auto-dismiss delay in milliseconds.
  */
 function swhToast( message, type, duration ) {
-	type     = type     || 'success';
+	var allowed = [ 'success', 'error', 'info' ];
+	type     = ( allowed.indexOf( type ) !== -1 ) ? type : 'success';
 	duration = duration || 4000;
 
 	var dismissLabel = ( typeof swhAdmin !== 'undefined' && swhAdmin.i18n && swhAdmin.i18n.dismissNotification )

--- a/simple-wp-helpdesk/assets/swh-admin.js
+++ b/simple-wp-helpdesk/assets/swh-admin.js
@@ -9,6 +9,62 @@
  * @package Simple_WP_Helpdesk
  */
 
+/* global swhAdmin */
+
+/**
+ * Displays a transient toast notification in the bottom-right corner.
+ *
+ * @param {string} message         - Text to display.
+ * @param {'success'|'error'|'info'} [type='success'] - Visual variant.
+ * @param {number} [duration=4000] - Auto-dismiss delay in milliseconds.
+ */
+function swhToast( message, type, duration ) {
+	type     = type     || 'success';
+	duration = duration || 4000;
+
+	var dismissLabel = ( typeof swhAdmin !== 'undefined' && swhAdmin.i18n && swhAdmin.i18n.dismissNotification )
+		? swhAdmin.i18n.dismissNotification
+		: 'Dismiss';
+
+	var toast = document.createElement( 'div' );
+	toast.className = 'swh-toast swh-toast--' + type;
+	toast.setAttribute( 'role', 'status' );
+	toast.setAttribute( 'aria-live', 'polite' );
+	toast.setAttribute( 'aria-atomic', 'true' );
+
+	var msg = document.createElement( 'span' );
+	msg.className   = 'swh-toast__message';
+	msg.textContent = message;
+
+	var btn = document.createElement( 'button' );
+	btn.className   = 'swh-toast__dismiss';
+	btn.type        = 'button';
+	btn.setAttribute( 'aria-label', dismissLabel );
+	btn.textContent = '×';
+
+	toast.appendChild( msg );
+	toast.appendChild( btn );
+	document.body.appendChild( toast );
+
+	var timer;
+
+	function dismiss() {
+		clearTimeout( timer );
+		toast.classList.remove( 'swh-toast--visible' );
+		toast.addEventListener( 'transitionend', function () { toast.remove(); }, { once: true } );
+	}
+
+	btn.addEventListener( 'click', dismiss );
+
+	requestAnimationFrame( function () {
+		requestAnimationFrame( function () {
+			toast.classList.add( 'swh-toast--visible' );
+		} );
+	} );
+
+	timer = setTimeout( dismiss, duration );
+}
+
 document.addEventListener( 'DOMContentLoaded', function () {
 	const tabs         = document.querySelectorAll( '[role="tab"]' );
 	const contents     = document.querySelectorAll( '.swh-tab-content' );

--- a/simple-wp-helpdesk/assets/swh-frontend.css
+++ b/simple-wp-helpdesk/assets/swh-frontend.css
@@ -121,25 +121,6 @@
 	background: var( --swh-color-bg );
 }
 
-/* Pill-style status badges (#259) */
-.swh-badge {
-	display: inline-block;
-	padding: 3px 10px;
-	border-radius: var( --swh-radius-pill );
-	font-size: var( --swh-font-sm );
-	font-weight: 600;
-	letter-spacing: 0.02em;
-}
-
-.swh-badge-closed {
-	background-color: var( --swh-color-error-bg );
-	color: var( --swh-color-error-text );
-}
-
-.swh-badge-open {
-	background-color: var( --swh-color-success-bg );
-	color: var( --swh-color-success-text );
-}
 
 .swh-chat-bubble {
 	padding: var( --swh-space-md );

--- a/simple-wp-helpdesk/assets/swh-frontend.js
+++ b/simple-wp-helpdesk/assets/swh-frontend.js
@@ -510,4 +510,11 @@ document.addEventListener( 'DOMContentLoaded', function () {
 			xhr.send( formData );
 		} );
 	}
+
+	// Focus the first error alert on page load so screen reader users hear it immediately (#336).
+	var firstError = document.querySelector( '.swh-alert-error' );
+	if ( firstError ) {
+		firstError.setAttribute( 'tabindex', '-1' );
+		firstError.focus( { preventScroll: false } );
+	}
 } );

--- a/simple-wp-helpdesk/assets/swh-reports.js
+++ b/simple-wp-helpdesk/assets/swh-reports.js
@@ -76,8 +76,34 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		}
 	}
 
-	// KPI summary cards.
+	// KPI summary cards — show skeletons while loading (#332, #335).
+	var kpiIds = [ 'total', 'open', 'resolution', 'first-response' ];
+
+	function showKpiSkeleton() {
+		var grid = document.getElementById( 'swh-kpi-grid' );
+		if ( grid ) { grid.setAttribute( 'aria-busy', 'true' ); }
+		kpiIds.forEach( function ( id ) {
+			var skel = document.getElementById( 'swh-kpi-' + id + '-skeleton' );
+			var val  = document.getElementById( 'swh-kpi-' + id );
+			if ( skel ) { skel.removeAttribute( 'hidden' ); }
+			if ( val )  { val.setAttribute( 'hidden', '' ); }
+		} );
+	}
+
+	function hideKpiSkeleton() {
+		var grid = document.getElementById( 'swh-kpi-grid' );
+		if ( grid ) { grid.setAttribute( 'aria-busy', 'false' ); }
+		kpiIds.forEach( function ( id ) {
+			var skel = document.getElementById( 'swh-kpi-' + id + '-skeleton' );
+			var val  = document.getElementById( 'swh-kpi-' + id );
+			if ( skel ) { skel.setAttribute( 'hidden', '' ); }
+			if ( val )  { val.removeAttribute( 'hidden' ); }
+		} );
+	}
+
+	showKpiSkeleton();
 	fetchReport( 'kpi' ).then( function ( data ) {
+		hideKpiSkeleton();
 		if ( ! data || data.__error ) { return; }
 		var total = document.getElementById( 'swh-kpi-total' );
 		var open  = document.getElementById( 'swh-kpi-open' );
@@ -87,12 +113,21 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		if ( open )  { open.textContent  = data.open; }
 		if ( res )   { res.textContent   = formatDuration( data.avg_resolution ); }
 		if ( frt )   { frt.textContent   = formatDuration( data.avg_first_response ); }
+	} ).catch( function () {
+		hideKpiSkeleton();
 	} );
 
 	// Status breakdown — doughnut chart.
+	var statusCard = document.getElementById( 'swh-report-card-status' );
+	var statusSkel = document.getElementById( 'swh-chart-status-skeleton' );
+	if ( statusCard ) { statusCard.setAttribute( 'aria-busy', 'true' ); }
+
 	fetchReport( 'status_breakdown' ).then( function ( data ) {
+		if ( statusCard ) { statusCard.setAttribute( 'aria-busy', 'false' ); }
+		if ( statusSkel ) { statusSkel.setAttribute( 'hidden', '' ); }
 		var ctx      = document.getElementById( 'swh-chart-status' );
 		var emptyEl  = document.getElementById( 'swh-chart-status-empty' );
+		if ( ctx ) { ctx.removeAttribute( 'hidden' ); }
 		if ( data && data.__error ) { showError( ctx, emptyEl, data.message ); return; }
 		var isEmpty  = ! data || ! Object.keys( data ).length || Object.values( data ).every( function ( v ) { return v === 0; } );
 		if ( ! ctx || isEmpty ) { showEmpty( ctx, emptyEl ); return; }
@@ -106,12 +141,26 @@ document.addEventListener( 'DOMContentLoaded', function () {
 			},
 			options: { plugins: { legend: { position: 'bottom' } } },
 		} );
+	} ).catch( function () {
+		if ( statusCard ) { statusCard.setAttribute( 'aria-busy', 'false' ); }
+		if ( statusSkel ) { statusSkel.setAttribute( 'hidden', '' ); }
+		var ctx     = document.getElementById( 'swh-chart-status' );
+		var emptyEl = document.getElementById( 'swh-chart-status-empty' );
+		if ( ctx ) { ctx.removeAttribute( 'hidden' ); }
+		showEmpty( ctx, emptyEl );
 	} );
 
 	// Weekly trend — bar chart.
+	var trendCard = document.getElementById( 'swh-report-card-trend' );
+	var trendSkel = document.getElementById( 'swh-chart-trend-skeleton' );
+	if ( trendCard ) { trendCard.setAttribute( 'aria-busy', 'true' ); }
+
 	fetchReport( 'weekly_trend' ).then( function ( data ) {
+		if ( trendCard ) { trendCard.setAttribute( 'aria-busy', 'false' ); }
+		if ( trendSkel ) { trendSkel.setAttribute( 'hidden', '' ); }
 		var ctx     = document.getElementById( 'swh-chart-trend' );
 		var emptyEl = document.getElementById( 'swh-chart-trend-empty' );
+		if ( ctx ) { ctx.removeAttribute( 'hidden' ); }
 		if ( data && data.__error ) { showError( ctx, emptyEl, data.message ); return; }
 		if ( ! ctx || ! data || ! data.length ) { showEmpty( ctx, emptyEl ); return; }
 		var labels  = data.map( function ( d ) { return d.week; } );
@@ -128,6 +177,13 @@ document.addEventListener( 'DOMContentLoaded', function () {
 			},
 			options: { plugins: { legend: { position: 'bottom' } }, scales: { x: { stacked: false } } },
 		} );
+	} ).catch( function () {
+		if ( trendCard ) { trendCard.setAttribute( 'aria-busy', 'false' ); }
+		if ( trendSkel ) { trendSkel.setAttribute( 'hidden', '' ); }
+		var ctx     = document.getElementById( 'swh-chart-trend' );
+		var emptyEl = document.getElementById( 'swh-chart-trend-empty' );
+		if ( ctx ) { ctx.removeAttribute( 'hidden' ); }
+		showEmpty( ctx, emptyEl );
 	} );
 
 	// Average resolution time.

--- a/simple-wp-helpdesk/assets/swh-shared.css
+++ b/simple-wp-helpdesk/assets/swh-shared.css
@@ -38,6 +38,7 @@
 	--swh-color-note-bd-hover:  #b38800;  /* internal note button hover border */
 	--swh-color-warning:        #d97706;  /* solid amber — KPI warning card, danger zone icons */
 	--swh-color-danger-surface: #fef2f2;  /* light red surface — settings danger zone background */
+	--swh-color-on-solid:       #fff;     /* text on solid-color backgrounds (badges, buttons) */
 
 	--swh-radius-sm:    4px;
 	--swh-radius-md:    5px;
@@ -95,8 +96,8 @@
 .swh-badge-resolved    { background-color: var( --swh-color-success-bg ); color: var( --swh-color-success-text ); }
 
 /* SLA modifiers (#329) */
-.swh-badge-sla-warn   { background-color: var( --swh-color-warning ); color: #fff; }
-.swh-badge-sla-breach { background-color: var( --swh-color-danger );   color: #fff; }
+.swh-badge-sla-warn   { background-color: var( --swh-color-warning ); color: var( --swh-color-on-solid ); }
+.swh-badge-sla-breach { background-color: var( --swh-color-danger );   color: var( --swh-color-on-solid ); }
 
 /* ── Empty state component — shared across admin and frontend (#319) ─────── */
 .swh-empty-state {

--- a/simple-wp-helpdesk/assets/swh-shared.css
+++ b/simple-wp-helpdesk/assets/swh-shared.css
@@ -56,6 +56,21 @@
 
 	--swh-transition-fast:   0.1s;
 	--swh-transition-normal: 0.2s;
+
+	/* Shadow scale (#331) */
+	--swh-shadow-sm:    0 1px 2px rgba( 0, 0, 0, 0.08 );
+	--swh-shadow-md:    0 2px 6px rgba( 0, 0, 0, 0.12 );
+	--swh-shadow-lg:    0 4px 12px rgba( 0, 0, 0, 0.16 );
+
+	/* Z-index scale (#331) */
+	--swh-z-base:       1;
+	--swh-z-dropdown:   100;
+	--swh-z-modal:      200;
+	--swh-z-toast:      300;
+
+	/* Easing functions (#331) */
+	--swh-ease-out:     cubic-bezier( 0, 0, 0.2, 1 );
+	--swh-ease-in-out:  cubic-bezier( 0.4, 0, 0.2, 1 );
 }
 
 /* ── Empty state component — shared across admin and frontend (#319) ─────── */

--- a/simple-wp-helpdesk/assets/swh-shared.css
+++ b/simple-wp-helpdesk/assets/swh-shared.css
@@ -100,7 +100,7 @@
 .swh-badge-resolved    { background-color: var( --swh-color-success-bg ); color: var( --swh-color-success-text ); }
 
 /* SLA modifiers (#329) */
-.swh-badge-sla-warn   { background-color: var( --swh-color-warning ); color: var( --swh-color-on-solid ); }
+.swh-badge-sla-warn   { background-color: var( --swh-color-warning-bg ); color: var( --swh-color-warning-text ); }
 .swh-badge-sla-breach { background-color: var( --swh-color-danger );   color: var( --swh-color-on-solid ); }
 
 /* ── Empty state component — shared across admin and frontend (#319) ─────── */

--- a/simple-wp-helpdesk/assets/swh-shared.css
+++ b/simple-wp-helpdesk/assets/swh-shared.css
@@ -157,3 +157,14 @@
 	--swh-color-primary:        #0073aa;
 	--swh-color-track:          #e0e0e0;
 }
+
+/* ── Reduced motion — disable transitions for users who prefer it ─────────── */
+@media ( prefers-reduced-motion: reduce ) {
+	*,
+	*::before,
+	*::after {
+		animation-duration: 0.01ms !important;
+		animation-iteration-count: 1 !important;
+		transition-duration: 0.01ms !important;
+	}
+}

--- a/simple-wp-helpdesk/assets/swh-shared.css
+++ b/simple-wp-helpdesk/assets/swh-shared.css
@@ -73,6 +73,31 @@
 	--swh-ease-in-out:  cubic-bezier( 0.4, 0, 0.2, 1 );
 }
 
+/* ── Unified pill badge — shared across admin and frontend (#330) ─────────── */
+.swh-badge {
+	display: inline-block;
+	padding: 3px 10px;
+	border-radius: var( --swh-radius-pill );
+	font-size: var( --swh-font-sm );
+	font-weight: 600;
+	letter-spacing: 0.02em;
+	white-space: nowrap;
+	transition: filter var( --swh-transition-fast ) var( --swh-ease-out );
+}
+
+.swh-badge:where(a, button) { cursor: pointer; }
+.swh-badge:where(a, button):hover { filter: brightness( 0.93 ); }
+
+/* Status modifiers — keyed on sanitize_title( $status ) (#329, #330) */
+.swh-badge-open        { background-color: var( --swh-color-info-bg );    color: var( --swh-color-info-text ); }
+.swh-badge-closed      { background-color: var( --swh-color-error-bg );   color: var( --swh-color-error-text ); }
+.swh-badge-in-progress { background-color: var( --swh-color-warning-bg ); color: var( --swh-color-warning-text ); }
+.swh-badge-resolved    { background-color: var( --swh-color-success-bg ); color: var( --swh-color-success-text ); }
+
+/* SLA modifiers (#329) */
+.swh-badge-sla-warn   { background-color: var( --swh-color-warning ); color: #fff; }
+.swh-badge-sla-breach { background-color: var( --swh-color-danger );   color: #fff; }
+
 /* ── Empty state component — shared across admin and frontend (#319) ─────── */
 .swh-empty-state {
 	text-align: center;

--- a/simple-wp-helpdesk/assets/swh-shared.css
+++ b/simple-wp-helpdesk/assets/swh-shared.css
@@ -88,6 +88,10 @@
 
 .swh-badge:where(a, button) { cursor: pointer; }
 .swh-badge:where(a, button):hover { filter: brightness( 0.93 ); }
+.swh-badge:where(a, button):focus-visible {
+	outline: 2px solid var( --swh-color-focus );
+	outline-offset: 2px;
+}
 
 /* Status modifiers — keyed on sanitize_title( $status ) (#329, #330) */
 .swh-badge-open        { background-color: var( --swh-color-info-bg );    color: var( --swh-color-info-text ); }

--- a/simple-wp-helpdesk/readme.txt
+++ b/simple-wp-helpdesk/readme.txt
@@ -3,7 +3,7 @@ Contributors: seanmousseau
 Tags: helpdesk, tickets, support, customer service, ticketing
 Requires at least: 5.3
 Tested up to: 6.7
-Stable tag: 3.4.1
+Stable tag: 3.5.0
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -73,6 +73,18 @@ Yes. Enable "Restrict Technicians" in Settings > Assignment & Routing. Technicia
 5. Settings page — Email Templates tab
 
 == Changelog ==
+
+= 3.5.0 =
+* Added: Unified badge system — `.swh-badge` base + `.swh-badge-{slug}` modifiers in `swh-shared.css`; all hardcoded hex colours removed (#329, #330)
+* Added: Design token scales — shadow (`--swh-shadow-*`), z-index (`--swh-z-*`), and easing (`--swh-ease-*`) tokens (#331)
+* Added: Reusable `swhToast()` notification component — auto-dismiss toast with success/error/info variants (#333)
+* Added: Settings save shows toast instead of legacy WP admin notice; URL param cleaned on display (#334)
+* Added: Reports page KPI skeleton loaders and `aria-busy` coverage (#332, #335)
+* Added: Focus return to first `.swh-alert-error` on page load for screen-reader users (#336)
+* Added: Ticket list row hover transition and focus rings on row actions and badges (#337)
+* Added: `prefers-reduced-motion` global safeguard in `swh-shared.css` (#337)
+* Added: E2E test sections 57 (toast) and 58 (reports loading states)
+* Changed: Duplicate `.swh-badge` block removed from `swh-frontend.css`
 
 = 3.4.1 =
 * Added: Frontend Portal Theme setting — "Force light mode" option pins portal to light mode on sites without dark mode support (#327)

--- a/simple-wp-helpdesk/simple-wp-helpdesk.php
+++ b/simple-wp-helpdesk/simple-wp-helpdesk.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Simple WP Helpdesk
  * Description: A comprehensive helpdesk system with auto-close, custom templates, multi-file attachments, internal notes, anti-spam, deep uninstallation cleanup, and GitHub auto-updates.
- * Version: 3.4.1
+ * Version: 3.5.0
  * Requires at least: 5.3
  * Requires PHP: 7.4
  * Text Domain: simple-wp-helpdesk
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWH_VERSION', '3.4.1' );
+define( 'SWH_VERSION', '3.5.0' );
 define( 'SWH_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWH_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWH_PLUGIN_FILE', __FILE__ );

--- a/testing/scripts/test_helpdesk_pw.py
+++ b/testing/scripts/test_helpdesk_pw.py
@@ -3592,10 +3592,10 @@ def test_58_reports_loading_states(page: Page):
           busy_after == 'false',
           f"aria-busy={busy_after!r}")
 
-    # KPI total text should be a number (not the placeholder dash).
+    # KPI total text should be a plain integer (not the placeholder dash or N/A).
     total_text = page.locator('#swh-kpi-total').inner_text().strip()
     check("reports #332: KPI total displays numeric value, not placeholder",
-          total_text not in ('', '—', '&mdash;', '—'),
+          bool(re.fullmatch(r'\d+', total_text)),
           f"total_text={total_text!r}")
 
     screenshot(page, "71_reports_kpi_loaded")

--- a/testing/scripts/test_helpdesk_pw.py
+++ b/testing/scripts/test_helpdesk_pw.py
@@ -3516,6 +3516,10 @@ def test_57_toast_notifications(page: Page):
 
     # Toast should appear with the --visible modifier class.
     toast = page.locator('.swh-toast.swh-toast--visible')
+    try:
+        toast.wait_for(state='visible', timeout=3000)
+    except Exception:
+        pass
     check("toast #333: toast is visible after settings save",
           toast.count() > 0,
           "toast element with .swh-toast--visible not found")

--- a/testing/scripts/test_helpdesk_pw.py
+++ b/testing/scripts/test_helpdesk_pw.py
@@ -3555,7 +3555,9 @@ def test_57_toast_notifications(page: Page):
             toast2_hidden = toast2.count() == 0 or toast2.first.is_hidden()
         check("toast #333: toast dismissed by clicking dismiss button", toast2_hidden)
     else:
-        skip("toast dismiss button", "second toast did not appear")
+        check("toast #333: second toast appeared for dismiss test",
+              toast2_visible,
+              "second toast did not appear after settings save")
 
 
 # ── v3.5.0 Reports loading states (#332, #335) ────────────────────────────────
@@ -3573,9 +3575,13 @@ def test_58_reports_loading_states(page: Page):
     skel = page.locator('#swh-kpi-total-skeleton')
     check("reports #332: KPI skeleton element present in DOM", skel.count() > 0)
 
-    # KPI grid aria-busy should be true initially (set in PHP, may flip quickly).
+    # KPI grid aria-busy should be true initially (set in PHP before AJAX fires).
     kpi_grid = page.locator('#swh-kpi-grid')
     check("reports #335: KPI grid exists", kpi_grid.count() > 0)
+    busy_before = kpi_grid.get_attribute('aria-busy')
+    check("reports #335: KPI grid aria-busy=true before AJAX load",
+          busy_before == 'true',
+          f"initial aria-busy={busy_before!r}")
 
     # Wait for AJAX to complete and KPI value to be unhidden.
     kpi_visible = False

--- a/testing/scripts/test_helpdesk_pw.py
+++ b/testing/scripts/test_helpdesk_pw.py
@@ -7,6 +7,8 @@ client portal, status transitions, internal notes, access control,
 bulk actions, canned responses, file attachments, portal token security,
 XSS escaping, rate limiting, and email trigger verification.
 
+34 original + 11 v3.0.0 + 7 v3.1.0 + 1 v3.2.0 + 1 v3.3.0 + 2 v3.4.0 + 2 v3.5.0 = 58 sections
+
 Running with pytest (recommended):
     source testing/.venv/bin/activate
     pytest testing/scripts/test_helpdesk_pw.py -v              # full suite
@@ -3499,6 +3501,87 @@ def test_56_dark_mode(page: Page):
         page.emulate_media(color_scheme="no-preference")
 
 
+# ── v3.5.0 Toast notifications (#333, #334) ──────────────────────────────────
+
+def test_57_toast_notifications(page: Page):
+    """v3.5.0 Settings save triggers a toast (#333/#334); it auto-dismisses."""
+    print("\n[57] Toast Notifications — settings save (#333/#334)")
+
+    wp_login(page, ADMIN_USER, ADMIN_PASS)
+    _navigate_settings(page)
+
+    # Submit the form to trigger the redirect with swh_notice=saved.
+    page.locator('#save-btn-container button[type="submit"]').click()
+    page.wait_for_load_state('networkidle')
+
+    # Toast should appear with the --visible modifier class.
+    toast = page.locator('.swh-toast.swh-toast--visible')
+    check("toast #333: toast is visible after settings save",
+          toast.count() > 0,
+          "toast element with .swh-toast--visible not found")
+
+    # URL should not contain swh_notice=saved after JS cleans it.
+    check("toast #334: URL param swh_notice=saved stripped by JS",
+          'swh_notice=saved' not in page.url,
+          f"URL still contains swh_notice=saved: {page.url!r}")
+
+    # Toast auto-dismisses within 6 seconds (4s timer + transition).
+    page.locator('.swh-toast.swh-toast--visible').wait_for(state='hidden', timeout=6000)
+    check("toast #333: toast auto-dismissed within 6s", True)
+
+    screenshot(page, "70_toast_after_settings_save")
+
+    # Dismiss button also works — trigger another save.
+    _navigate_settings(page)
+    page.locator('#save-btn-container button[type="submit"]').click()
+    page.wait_for_load_state('networkidle')
+    toast2 = page.locator('.swh-toast.swh-toast--visible')
+    if toast2.count() > 0:
+        page.locator('.swh-toast__dismiss').click()
+        page.locator('.swh-toast.swh-toast--visible').wait_for(state='hidden', timeout=2000)
+        check("toast #333: toast dismissed by clicking × button", True)
+    else:
+        skip("toast dismiss button", "second toast did not appear")
+
+
+# ── v3.5.0 Reports loading states (#332, #335) ────────────────────────────────
+
+def test_58_reports_loading_states(page: Page):
+    """v3.5.0 Reports page KPI skeletons + aria-busy; values populate after AJAX (#332/#335)."""
+    print("\n[58] Reports Loading States — skeletons + aria-busy (#332/#335)")
+
+    wp_login(page, ADMIN_USER, ADMIN_PASS)
+    reports_url = f"{WP_ADMIN_URL}/edit.php?post_type=helpdesk_ticket&page=swh-reports"
+    page.goto(reports_url)
+    page.wait_for_load_state('domcontentloaded')
+
+    # KPI skeleton element should exist in the DOM.
+    skel = page.locator('#swh-kpi-total-skeleton')
+    check("reports #332: KPI skeleton element present in DOM", skel.count() > 0)
+
+    # KPI grid aria-busy should be true initially (set in PHP, may flip quickly).
+    kpi_grid = page.locator('#swh-kpi-grid')
+    check("reports #335: KPI grid exists", kpi_grid.count() > 0)
+
+    # Wait for AJAX to complete and KPI value to be unhidden.
+    page.locator('#swh-kpi-total:not([hidden])').wait_for(timeout=10000)
+    check("reports #332: KPI total value becomes visible after AJAX", True)
+
+    # After load, aria-busy should be 'false'.
+    busy_after = kpi_grid.get_attribute('aria-busy')
+    check("reports #335: KPI grid aria-busy=false after data loads",
+          busy_after == 'false',
+          f"aria-busy={busy_after!r}")
+
+    # KPI total text should be a number (not the placeholder dash).
+    total_text = page.locator('#swh-kpi-total').inner_text().strip()
+    check("reports #332: KPI total displays numeric value, not placeholder",
+          total_text not in ('', '—', '&mdash;', '—'),
+          f"total_text={total_text!r}")
+
+    screenshot(page, "71_reports_kpi_loaded")
+
+
 # ── Cleanup ───────────────────────────────────────────────────────────────────
 
 def test_28_cleanup(page: Page):
@@ -3607,6 +3690,8 @@ SECTIONS = [
     test_54_responsive,               # 54 — v3.3.0 responsive layout (#251)
     test_55_email_branding,           # 55 — v3.4.0 email branding (#317)
     test_56_dark_mode,                # 56 — v3.4.0 dark mode (#321)
+    test_57_toast_notifications,      # 57 — v3.5.0 toast (#333/#334)
+    test_58_reports_loading_states,   # 58 — v3.5.0 reports skeletons (#332/#335)
     test_28_cleanup,                  # 28 — always last
 ]
 

--- a/testing/scripts/test_helpdesk_pw.py
+++ b/testing/scripts/test_helpdesk_pw.py
@@ -3553,7 +3553,7 @@ def test_57_toast_notifications(page: Page):
         with suppress(PlaywrightTimeoutError):
             toast2.wait_for(state='hidden', timeout=2000)
             toast2_hidden = toast2.count() == 0 or toast2.first.is_hidden()
-        check("toast #333: toast dismissed by clicking × button", toast2_hidden)
+        check("toast #333: toast dismissed by clicking dismiss button", toast2_hidden)
     else:
         skip("toast dismiss button", "second toast did not appear")
 
@@ -3578,8 +3578,13 @@ def test_58_reports_loading_states(page: Page):
     check("reports #335: KPI grid exists", kpi_grid.count() > 0)
 
     # Wait for AJAX to complete and KPI value to be unhidden.
-    page.locator('#swh-kpi-total:not([hidden])').wait_for(timeout=10000)
-    check("reports #332: KPI total value becomes visible after AJAX", True)
+    kpi_visible = False
+    with suppress(PlaywrightTimeoutError):
+        page.locator('#swh-kpi-total:not([hidden])').wait_for(timeout=10000)
+        kpi_visible = page.locator('#swh-kpi-total:not([hidden])').count() > 0
+    check("reports #332: KPI total value becomes visible after AJAX",
+          kpi_visible,
+          "#swh-kpi-total remained hidden after AJAX")
 
     # After load, aria-busy should be 'false'.
     busy_after = kpi_grid.get_attribute('aria-busy')

--- a/testing/scripts/test_helpdesk_pw.py
+++ b/testing/scripts/test_helpdesk_pw.py
@@ -3516,12 +3516,12 @@ def test_57_toast_notifications(page: Page):
 
     # Toast should appear with the --visible modifier class.
     toast = page.locator('.swh-toast.swh-toast--visible')
-    try:
+    toast_visible = False
+    with suppress(PlaywrightTimeoutError):
         toast.wait_for(state='visible', timeout=3000)
-    except Exception:
-        pass
+        toast_visible = toast.count() > 0 and toast.first.is_visible()
     check("toast #333: toast is visible after settings save",
-          toast.count() > 0,
+          toast_visible,
           "toast element with .swh-toast--visible not found")
 
     # URL should not contain swh_notice=saved after JS cleans it.
@@ -3530,8 +3530,11 @@ def test_57_toast_notifications(page: Page):
           f"URL still contains swh_notice=saved: {page.url!r}")
 
     # Toast auto-dismisses within 6 seconds (4s timer + transition).
-    page.locator('.swh-toast.swh-toast--visible').wait_for(state='hidden', timeout=6000)
-    check("toast #333: toast auto-dismissed within 6s", True)
+    toast_hidden = False
+    with suppress(PlaywrightTimeoutError):
+        toast.wait_for(state='hidden', timeout=6000)
+        toast_hidden = toast.count() == 0 or toast.first.is_hidden()
+    check("toast #333: toast auto-dismissed within 6s", toast_hidden)
 
     screenshot(page, "70_toast_after_settings_save")
 
@@ -3540,10 +3543,17 @@ def test_57_toast_notifications(page: Page):
     page.locator('#save-btn-container input[type="submit"]').click()
     page.wait_for_load_state('networkidle')
     toast2 = page.locator('.swh-toast.swh-toast--visible')
-    if toast2.count() > 0:
+    toast2_visible = False
+    with suppress(PlaywrightTimeoutError):
+        toast2.wait_for(state='visible', timeout=3000)
+        toast2_visible = toast2.count() > 0 and toast2.first.is_visible()
+    if toast2_visible:
         page.locator('.swh-toast__dismiss').click()
-        page.locator('.swh-toast.swh-toast--visible').wait_for(state='hidden', timeout=2000)
-        check("toast #333: toast dismissed by clicking × button", True)
+        toast2_hidden = False
+        with suppress(PlaywrightTimeoutError):
+            toast2.wait_for(state='hidden', timeout=2000)
+            toast2_hidden = toast2.count() == 0 or toast2.first.is_hidden()
+        check("toast #333: toast dismissed by clicking × button", toast2_hidden)
     else:
         skip("toast dismiss button", "second toast did not appear")
 

--- a/testing/scripts/test_helpdesk_pw.py
+++ b/testing/scripts/test_helpdesk_pw.py
@@ -3511,7 +3511,7 @@ def test_57_toast_notifications(page: Page):
     _navigate_settings(page)
 
     # Submit the form to trigger the redirect with swh_notice=saved.
-    page.locator('#save-btn-container button[type="submit"]').click()
+    page.locator('#save-btn-container input[type="submit"]').click()
     page.wait_for_load_state('networkidle')
 
     # Toast should appear with the --visible modifier class.
@@ -3533,7 +3533,7 @@ def test_57_toast_notifications(page: Page):
 
     # Dismiss button also works — trigger another save.
     _navigate_settings(page)
-    page.locator('#save-btn-container button[type="submit"]').click()
+    page.locator('#save-btn-container input[type="submit"]').click()
     page.wait_for_load_state('networkidle')
     toast2 = page.locator('.swh-toast.swh-toast--visible')
     if toast2.count() > 0:


### PR DESCRIPTION
## Summary

- **Design-system consolidation** — unified `.swh-badge` system (slug-keyed modifiers), shadow/z-index/easing token scales, and `--swh-color-on-solid` token. All hardcoded hex colours removed from admin and editor (#329, #330, #331)
- **Toast notification component** — reusable `swhToast()` in `swh-admin.js`; settings save replaced legacy WP notice with a toast; URL param cleaned via `replaceState` (#333, #334)
- **Reports skeleton loaders + `aria-busy`** — KPI cards and chart canvases shimmer while AJAX is in flight; `aria-busy` toggled on KPI grid and chart cards (#332, #335)
- **Accessibility** — focus returns to first `.swh-alert-error` on DOMContentLoaded; ticket list rows get hover transition + focus rings; `prefers-reduced-motion` global safeguard (#336, #337)
- **E2E** — sections 57 (toast) and 58 (reports loading states)
- **Infra** — `doctrine/instantiator` pinned to `^1.5` for PHP 8.2 compatibility

Closes #329, #330, #331, #332, #333, #334, #335, #336, #337

## Test plan

- [x] `make test-docker` — lint ✓ PHPCS ✓ PHPStan ✓ PHPUnit (52/52) ✓ Semgrep ✓
- [x] Pre-push hook passed on branch push
- [ ] `make e2e-docker` — run E2E suite including sections 57 + 58
- [ ] `/review` CodeRabbit review — address all actionable findings before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toast notification system (bottom-right, variants, auto-dismiss, accessible dismiss) and URL cleanup after settings save.

* **UI/UX Improvements**
  * Reports: skeleton loaders with aria-busy during loading.
  * Unified badge styling via shared design tokens (status & SLA modifiers).
  * Improved hover/focus outlines, reduced-motion support, and auto-focus for first error alerts.

* **Documentation**
  * Docs for toast usage and design-token/badge conventions.

* **Tests**
  * E2E coverage for toast behavior and reports loading states.

* **Chores**
  * Release bumped to 3.5.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->