### PR TITLE
docs: launch GitHub Pages documentation site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ starting from the next release after 1.8.
 
 - GitHub Pages documentation site at `https://seanmousseau.github.io/Simple-WP-Helpdesk/` (Jekyll, just-the-docs theme) — covers all features through v3.5.0.
 - New docs pages: Shortcode Reference, Hooks Reference (all 9 filters + 2 actions with examples), Troubleshooting / FAQ.
-- Plugin Plugins-page action links: **Settings** and **Docs** shortcut links shown under the plugin name.
+- Plugins page action links: **Settings** and **Docs** shortcuts shown under the plugin name.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ starting from the next release after 1.8.
 
 ## [Unreleased]
 
+### Added
+
+- GitHub Pages documentation site at `https://seanmousseau.github.io/Simple-WP-Helpdesk/` (Jekyll, just-the-docs theme) — covers all features through v3.5.0.
+- New docs pages: Shortcode Reference, Hooks Reference (all 9 filters + 2 actions with examples), Troubleshooting / FAQ.
+- Plugin Plugins-page action links: **Settings** and **Docs** shortcut links shown under the plugin name.
+
+### Changed
+
+- `README.md` updated to v3.5.0 with expanded features list reflecting all v3.x additions.
+- `docs/configuration.md` corrected from 6 tabs to 8; Canned Responses and Templates tabs documented.
+- `docs/development.md` updated repo structure, removed stale bootstrap size note, added Inbound Email Webhook section.
+- `docs/usage.md` expanded technician section (categories, SLA, merge, reporting, canned responses).
+- `docs/security.md` additions: token empty-value rejection, inbound webhook Bearer auth, MIME filter hook.
+
 ---
 
 ## [3.5.0] — 2026-04-23

--- a/README.md
+++ b/README.md
@@ -4,25 +4,38 @@
 
 A lightweight, full-featured ticketing system built natively for WordPress. No third-party services required — all data stays on your server.
 
-**Version:** 2.0.0 &nbsp;|&nbsp; **WordPress:** 5.3+ &nbsp;|&nbsp; **PHP:** 7.4+
+**Version:** 3.5.0 &nbsp;|&nbsp; **WordPress:** 5.3+ &nbsp;|&nbsp; **PHP:** 7.4+
 
 ## Features
 
 - **Custom Post Type** for tickets — no custom database tables
 - **Frontend submission form** and **secure token-based client portal** via `[submit_ticket]` shortcode
-- **Optional dedicated portal page** via `[helpdesk_portal]` shortcode — separate from the submission form
-- **Tabbed settings panel** with 6 tabs (General, Assignment & Routing, Email Templates, Messages, Anti-Spam, Tools)
-- **Multi-file upload** with client-side validation and configurable size/count limits
+- **Optional dedicated portal page** via `[helpdesk_portal]` shortcode
+- **8-tab settings panel** (General, Assignment & Routing, Email Templates, Messages, Anti-Spam, Canned Responses, Templates, Tools)
+- **Canned responses** — save reply templates in Settings and insert them from within the ticket editor
+- **Ticket templates** — pre-configured request types that pre-fill the description field at submission
+- **Multi-file upload** with XHR progress bar, drag-and-drop, and configurable size/count limits
 - **Technician role** with optional assignment restriction (`swh_restrict_to_assigned`)
 - **HTML and plain-text email notifications** — 14 fully customizable templates with dynamic placeholders and conditional blocks (`{if key}...{endif key}`)
+- **Email branding** — header band with logo, site name, and footer; `swh_email_logo_url` option
 - **Background automation** — auto-close resolved tickets and scheduled data retention
 - **Anti-spam** on all forms — honeypot, Google reCAPTCHA v2, and Cloudflare Turnstile
-- **CDN/proxy-aware rate limiting** via `swh_get_client_ip()` with per-action keys
+- **CDN/proxy-aware rate limiting** — persistent, per-action keys, survives cache flushes
 - **Protected file uploads** served through a proxy endpoint (no direct URL access)
 - **Token expiration** with configurable TTL and auto-rotation for portal links
 - **"Resend my ticket links"** client lookup form with anti-enumeration messaging
-- **Internationalization (i18n)** ready with full text-domain support
-- **GDPR tools** — per-email data purge, data retention policies, and full uninstall cleanup
+- **My Tickets dashboard** — card list for logged-in users; lookup form for guests
+- **Categories taxonomy** — hierarchical departments with list filter and auto-assignment rules
+- **SLA breach alerts** — configurable warn/breach thresholds, row highlighting, admin digest email
+- **Reporting dashboard** — status breakdown, weekly trend, avg resolution + first response (Chart.js)
+- **KPI cards** — total, open, avg resolution time, avg first response time
+- **Ticket merge** — consolidate duplicate tickets from the admin UI
+- **Full dark mode** — `prefers-color-scheme: dark` token overrides; force-light escape hatch
+- **Unified design token system** — shadow, z-index, and easing scales in `swh-shared.css`
+- **CSAT satisfaction prompt** — optional 1–5 star rating after ticket closure
+- **GDPR tools** — per-email data purge, retention policies, full uninstall cleanup
+- **Inbound email webhook** — `POST /wp-json/swh/v1/inbound-email` with Bearer auth
+- **Internationalization (i18n)** ready with full `.pot` file
 - **GitHub auto-updater** — new releases delivered directly to the WordPress dashboard
 
 ## Quick Start
@@ -30,18 +43,23 @@ A lightweight, full-featured ticketing system built natively for WordPress. No t
 1. Download `simple-wp-helpdesk.zip` from the [latest release](https://github.com/seanmousseau/Simple-WP-Helpdesk/releases/latest).
 2. In WordPress, go to **Plugins > Add New > Upload Plugin** and install the ZIP.
 3. Activate the plugin. A **Tickets** menu appears in the dashboard.
-4. Create a page for clients (e.g., "Support") and add `[submit_ticket]` — or use separate pages: `[submit_ticket]` for the form and `[helpdesk_portal]` for the portal.
+4. Create a page for clients (e.g. "Support") and add `[submit_ticket]` — or use separate pages: `[submit_ticket]` for the form and `[helpdesk_portal]` for the portal.
 5. Go to **Tickets > Settings > Assignment & Routing** and set the **Helpdesk Page** to the page clients should land on when clicking their portal link.
 
 ## Documentation
 
-Detailed guides are available in the [`docs/`](docs/) folder:
+Full documentation is available at **[seanmousseau.github.io/Simple-WP-Helpdesk](https://seanmousseau.github.io/Simple-WP-Helpdesk/)**.
 
-- [Installation](docs/installation.md) — install, update, and uninstall
-- [Configuration](docs/configuration.md) — all settings tabs explained
-- [Usage](docs/usage.md) — guide for clients and technicians
-- [Security](docs/security.md) — token auth, anti-spam, nonces, input handling
-- [Development](docs/development.md) — architecture, conventions, and release process
+Quick links:
+
+- [Installation](https://seanmousseau.github.io/Simple-WP-Helpdesk/installation) — install, update, and uninstall
+- [Configuration](https://seanmousseau.github.io/Simple-WP-Helpdesk/configuration) — all settings tabs explained
+- [Usage Guide](https://seanmousseau.github.io/Simple-WP-Helpdesk/usage) — guide for clients and technicians
+- [Shortcode Reference](https://seanmousseau.github.io/Simple-WP-Helpdesk/shortcodes) — all shortcodes, attributes, and examples
+- [Security](https://seanmousseau.github.io/Simple-WP-Helpdesk/security) — token auth, anti-spam, nonces, input handling
+- [Development Guide](https://seanmousseau.github.io/Simple-WP-Helpdesk/development) — architecture, conventions, and release process
+- [Hooks Reference](https://seanmousseau.github.io/Simple-WP-Helpdesk/hooks) — PHP filters and actions
+- [Troubleshooting](https://seanmousseau.github.io/Simple-WP-Helpdesk/troubleshooting) — common issues and FAQ
 
 ## Changelog
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,33 @@
+title: Simple WP Helpdesk
+description: A lightweight, full-featured ticketing system built natively for WordPress. No third-party services — all data stays on your server.
+remote_theme: just-the-docs/just-the-docs
+url: https://seanmousseau.github.io/Simple-WP-Helpdesk
+baseurl: /Simple-WP-Helpdesk
+
+logo: https://media.seanmousseau.com/file/seanmousseau/assets/logos/swh/logo.webp
+
+color_scheme: light
+
+search_enabled: true
+search_tokenizer_separator: /[\s/]+/
+
+aux_links:
+  "GitHub":
+    - "https://github.com/seanmousseau/Simple-WP-Helpdesk"
+  "Latest Release":
+    - "https://github.com/seanmousseau/Simple-WP-Helpdesk/releases/latest"
+
+aux_links_new_tab: true
+
+footer_content: 'Copyright &copy; Sean Mousseau. Released under the <a href="https://www.gnu.org/licenses/gpl-2.0.html">GPLv2 license</a>.'
+
+gh_edit_link: true
+gh_edit_link_text: "Edit this page on GitHub"
+gh_edit_repository: "https://github.com/seanmousseau/Simple-WP-Helpdesk"
+gh_edit_branch: "main"
+gh_edit_source: docs
+gh_edit_view_mode: "edit"
+
+plugins:
+  - jekyll-remote-theme
+  - jekyll-seo-tag

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,11 @@
+---
+title: Configuration
+nav_order: 3
+---
+
 # Configuration
 
-Navigate to **Tickets → Settings** in your WordPress dashboard. Settings are organized across six tabs.
+Navigate to **Tickets → Settings** in your WordPress dashboard. Settings are organized across eight tabs.
 
 ---
 
@@ -8,9 +13,9 @@ Navigate to **Tickets → Settings** in your WordPress dashboard. Settings are o
 
 | Setting | Description | Default |
 |---------|-------------|---------|
-| **Ticket Priorities** | Comma-separated list of priority levels | `Low, Medium, High` |
-| **Ticket Statuses** | Comma-separated list of workflow statuses | `Open, In Progress, Resolved, Closed` |
+| **Custom Priorities** | Comma-separated list of priority levels | `Low, Medium, High` |
 | **Default Priority** | Priority assigned to new tickets | `Medium` |
+| **Custom Statuses** | Comma-separated list of workflow statuses | `Open, In Progress, Resolved, Closed` |
 | **Default Status** | Status assigned to new tickets | `Open` |
 | **Resolved Status** | Triggers the auto-close countdown | `Resolved` |
 | **Closed Status** | Disables further client replies | `Closed` |
@@ -18,6 +23,10 @@ Navigate to **Tickets → Settings** in your WordPress dashboard. Settings are o
 | **Auto-Close Days** | Days after "Resolved" before automatic closure (0 = disabled) | `3` |
 | **Max Upload Size** | Maximum file size per upload in MB | `5` |
 | **Max Files Per Upload** | Maximum number of files per submission (0 = unlimited) | `5` |
+| **SLA Warn Hours** | Hours before a ticket is flagged as an SLA warning | `0` (disabled) |
+| **SLA Breach Hours** | Hours before a ticket is flagged as an SLA breach | `0` (disabled) |
+| **Restrict Technicians** | When enabled, technicians only see tickets assigned to them | Off |
+| **Portal Theme** | `Auto` follows `prefers-color-scheme`; `Force light mode` pins the portal to light | `Auto` |
 
 ---
 
@@ -28,6 +37,8 @@ Navigate to **Tickets → Settings** in your WordPress dashboard. Settings are o
 | **Default Assignee** | Technician automatically assigned to every new ticket |
 | **Fallback Alert Email** | Receives new-ticket and client-reply notifications when no assignee is set |
 | **Helpdesk Page** | The page clients land on when clicking their portal link. Use the `[helpdesk_portal]` page if you have a dedicated portal, or the `[submit_ticket]` page for a combined layout. All portal links in emails point here. |
+
+**Auto-assignment rules** let you route tickets to specific technicians based on category. Add one or more rules mapping a **Category** to an **Assignee**. The first matching rule wins; if no rule matches, the default assignee is used.
 
 **Email routing priority** (when sending admin notifications):
 1. The ticket's assigned technician
@@ -88,6 +99,10 @@ Unreplaced placeholders are automatically removed from the final output.
 - Ticket assigned to technician
 - Ticket auto-closed (admin copy)
 
+**Email branding:** The header band displays your site logo (configured via **Logo URL** in Tab 3) and site name. If no logo URL is set, the site icon is used as a fallback (at 32×32 px). All CSS is inlined for email client compatibility.
+
+**Send Test Email:** Click **Send Test Email** to send a sample message to the currently logged-in admin. The result is shown inline without a page reload.
+
 ---
 
 ## Tab 4: Messages
@@ -117,9 +132,35 @@ Customize the front-end text shown to clients after form actions:
 
 For reCAPTCHA and Turnstile, paste your public **Site Key** and private **Secret Key** into the respective fields. The widget renders automatically on the frontend form.
 
+Protection applies to: the ticket submission form, the ticket lookup form, and the portal reply/close/reopen forms.
+
 ---
 
-## Tab 6: Tools
+## Tab 6: Canned Responses
+
+Pre-written reply templates that speed up ticket responses.
+
+- Click **+ Add Response** to create a new template.
+- Enter a **Title** (visible only in the selector) and a **Body** (inserted into the reply field).
+- Save via the main **Save Changes** button.
+
+To use a canned response in a ticket, open the ticket editor, click the **Canned Response** picker in the conversation section, and select a template. The body is inserted into the active reply field.
+
+---
+
+## Tab 7: Templates
+
+Pre-configured submission types that pre-fill the ticket description field when a client selects them on the frontend form.
+
+- Click **+ Add Template** to create a new request type.
+- Enter a **Label** (shown as the option name in the dropdown) and a **Description** (the pre-filled text).
+- Save via the main **Save Changes** button.
+
+When templates are configured, the submission form displays a **Request Type** dropdown. Selecting an option populates the description field with the corresponding template body, which the client can then edit before submitting.
+
+---
+
+## Tab 8: Tools
 
 ### Automated Data Retention
 
@@ -144,13 +185,11 @@ Check **Delete all plugin data on uninstall** to permanently remove all tickets,
 
 ---
 
-## UX Feedback
-
-### Toast Notifications
+## Toast Notifications
 
 After saving settings, a toast notification slides in from the bottom-right corner confirming the save. It auto-dismisses after ~4 seconds and can be closed immediately with the **×** button.
 
-Toast notifications are built on `swhToast(message, type, duration)` in `swh-admin.js`. The function is available globally on any page that loads `swh-admin.js`.
+The `swhToast(message, type, duration)` function is available globally on any page that loads `swh-admin.js`:
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|

--- a/docs/development.md
+++ b/docs/development.md
@@ -16,7 +16,7 @@ Simple-WP-Helpdesk/
 ├── CLAUDE.md                            # AI assistant guidance
 ├── README.md
 ├── LICENSE
-├── Makefile                             # Local test gate (lint/phpcs/phpstan/phpunit/semgrep/e2e)
+├── Makefile                             # Local PHP gate (lint/phpcs/phpstan/phpunit/semgrep); E2E via make e2e-docker
 ├── composer.json
 ├── docker-compose.test.yml              # Docker test stack (WP + MySQL + MailHog)
 ├── docker/
@@ -58,7 +58,7 @@ Simple-WP-Helpdesk/
         └── simple-wp-helpdesk.pot
 ```
 
-The bootstrap file (`simple-wp-helpdesk.php`) is a thin loader (~160 lines). Admin files are only loaded inside `is_admin()`. Constants: `SWH_PLUGIN_DIR`, `SWH_PLUGIN_URL`, `SWH_PLUGIN_FILE`.
+The bootstrap file (`simple-wp-helpdesk.php`) is a thin loader — admin files are only loaded inside `is_admin()`. Constants: `SWH_PLUGIN_DIR`, `SWH_PLUGIN_URL`, `SWH_PLUGIN_FILE`.
 
 ---
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,3 +1,9 @@
+---
+title: Development Guide
+nav_order: 7
+has_children: true
+---
+
 # Development Guide
 
 ---
@@ -10,7 +16,20 @@ Simple-WP-Helpdesk/
 ├── CLAUDE.md                            # AI assistant guidance
 ├── README.md
 ├── LICENSE
-├── docs/                                # This documentation
+├── Makefile                             # Local test gate (lint/phpcs/phpstan/phpunit/semgrep/e2e)
+├── composer.json
+├── docker-compose.test.yml              # Docker test stack (WP + MySQL + MailHog)
+├── docker/
+│   ├── setup-test-wp.sh                 # Configures the Docker WP instance for E2E tests
+│   └── mailhog-smtp.php                 # MU-plugin: routes wp_mail() through MailHog
+├── docs/                                # This documentation (GitHub Pages source)
+├── testing/
+│   ├── scripts/
+│   │   ├── test_helpdesk_pw.py          # Playwright E2E test suite (58 sections)
+│   │   └── conftest.py                  # pytest fixtures and helpers
+│   ├── pytest.ini
+│   ├── requirements.txt
+│   └── .env.example
 └── simple-wp-helpdesk/
     ├── simple-wp-helpdesk.php           # Bootstrap: constants, requires, lifecycle hooks
     ├── includes/
@@ -18,20 +37,28 @@ Simple-WP-Helpdesk/
     │   ├── class-installer.php          # Activation, deactivation, uninstall, upgrade, CPT
     │   ├── class-email.php              # Template parsing, email sending, HTML wrapping
     │   ├── class-ticket.php             # File proxy, uploads, deletion, comment filters
-    │   └── class-cron.php              # Auto-close, retention (tickets + attachments)
+    │   └── class-cron.php               # Auto-close, SLA check, retention (tickets + files)
     ├── admin/
-    │   ├── class-settings.php           # Settings page render + save handler
+    │   ├── class-settings.php           # Settings page render + save handler (8 tabs)
     │   ├── class-ticket-editor.php      # Meta boxes, save_post, conversation UI
-    │   └── class-ticket-list.php        # Columns, sorting, filters, admin styles
+    │   ├── class-ticket-list.php        # Columns, sorting, filters, bulk actions
+    │   ├── class-reporting.php          # Reporting AJAX endpoints (status, resolution, trend, KPI)
+    │   └── class-reporting-ui.php       # Reports submenu page render + Chart.js enqueue
     ├── frontend/
     │   ├── class-shortcode.php          # [submit_ticket] + [helpdesk_portal] shortcodes
     │   └── class-portal.php             # Client portal view
     ├── vendor/plugin-update-checker/    # GitHub auto-updater library
-    ├── assets/                          # CSS, JS
-    └── languages/                       # .pot/.po/.mo
+    ├── assets/
+    │   ├── swh-shared.css               # Design tokens + shared components
+    │   ├── swh-admin.css                # Admin-only styles
+    │   ├── swh-frontend.css             # Frontend styles
+    │   ├── swh-admin.js                 # Admin JS (toast, canned responses, etc.)
+    │   └── swh-frontend.js              # Frontend JS (form, portal interactions)
+    └── languages/
+        └── simple-wp-helpdesk.pot
 ```
 
-The bootstrap file (`simple-wp-helpdesk.php`) is a loader (~160 lines, including the GitHub auto-updater initialisation and plugin icon injection). Admin files are only loaded inside `is_admin()`. Constants: `SWH_PLUGIN_DIR`, `SWH_PLUGIN_URL`, `SWH_PLUGIN_FILE`.
+The bootstrap file (`simple-wp-helpdesk.php`) is a thin loader (~160 lines). Admin files are only loaded inside `is_admin()`. Constants: `SWH_PLUGIN_DIR`, `SWH_PLUGIN_URL`, `SWH_PLUGIN_FILE`.
 
 ---
 
@@ -40,9 +67,10 @@ The bootstrap file (`simple-wp-helpdesk.php`) is a loader (~160 lines, including
 ```bash
 git clone https://github.com/seanmousseau/Simple-WP-Helpdesk.git
 cd Simple-WP-Helpdesk
+composer install
 ```
 
-No build step is required. Drop the `simple-wp-helpdesk/` folder into your WordPress `wp-content/plugins/` directory and activate it from the WordPress dashboard.
+No build step is required for the plugin itself. Drop the `simple-wp-helpdesk/` folder into your WordPress `wp-content/plugins/` directory and activate it from the WordPress dashboard.
 
 ---
 
@@ -54,13 +82,15 @@ The plugin uses only WordPress core data structures:
 
 | Data | Storage | Key Meta |
 |------|---------|----------|
-| Tickets | `helpdesk_ticket` Custom Post Type | `_ticket_uid`, `_ticket_token`, `_ticket_status`, `_ticket_priority`, `_ticket_email`, `_ticket_attachments`, `_swh_attachment_orignames`, `_ticket_csat`, etc. |
-| Replies & Notes | WP Comments on the CPT | `_is_internal_note`, `_is_user_reply`, `_swh_reply_orignames` |
+| Tickets | `helpdesk_ticket` Custom Post Type | `_ticket_uid`, `_ticket_token`, `_ticket_status`, `_ticket_priority`, `_ticket_email`, `_ticket_attachments`, `_ticket_csat`, etc. |
+| Replies & Notes | WP Comments (`comment_type = 'helpdesk_reply'`) | `_is_internal_note`, `_is_user_reply`, `_swh_reply_orignames` |
 | Settings | `wp_options` | All keys prefixed with `swh_` |
+| Canned responses | `wp_options` | `swh_canned_responses` (JSON array) |
+| Ticket templates | `wp_options` | `swh_ticket_templates` (JSON array) |
 
-### Function Naming
+### Function & Class Naming
 
-All functions use the `swh_` prefix:
+All public functions use the `swh_` prefix; all classes use `SWH_`:
 
 ```php
 swh_activate()
@@ -71,11 +101,12 @@ swh_save_ticket_data()
 
 ### Single Source of Truth for Defaults
 
-**`swh_get_defaults()`** is the definitive list of every plugin option and its default value. It uses a `static $defaults` cache so it is only built once per request.
+**`swh_get_defaults()`** (`includes/helpers.php`) is the definitive list of every plugin option and its default value. It uses a `static $defaults` cache so it is built only once per request.
 
 When adding a new option:
-1. Add it to `swh_get_defaults()` with its default value.
-2. It will automatically be registered by the upgrade routine, included in factory reset, and cleaned up on uninstall.
+1. Add it to `swh_get_defaults()` with its default value — it is automatically registered by the upgrade routine, included in factory reset, and cleaned up on uninstall.
+2. Add the field to the appropriate settings tab in `admin/class-settings.php`.
+3. Add it to the correct save block in `swh_handle_settings_save()` (main form or Tools form — see below).
 
 ---
 
@@ -83,12 +114,12 @@ When adding a new option:
 
 ### New Option
 
-1. Add to `swh_get_defaults()` in `includes/helpers.php`:
-   ```php
-   'swh_my_new_option' => 'default_value',
-   ```
-2. Add the field to the appropriate settings tab in `admin/class-settings.php`.
-3. Add it to the correct save block in `swh_handle_settings_save()` — the main form handler (guarded by `swh_settings_nonce`) or the Tools form handler (guarded by `swh_tools_nonce`).
+```php
+// 1. includes/helpers.php — swh_get_defaults()
+'swh_my_new_option' => 'default_value',
+```
+
+Then add the field to `admin/class-settings.php` and the corresponding save block.
 
 ### New Email Template
 
@@ -100,19 +131,18 @@ Add both variants to `swh_get_defaults()`:
 
 ### New Cron Job
 
-1. Register in `swh_activate()`:
-   ```php
-   wp_schedule_event( time() + OFFSET_SECONDS, 'hourly', 'swh_my_event' );
-   ```
-2. Clear in `swh_deactivate()`:
-   ```php
-   wp_clear_scheduled_hook( 'swh_my_event' );
-   ```
-3. Hook the handler:
-   ```php
-   add_action( 'swh_my_event', 'swh_process_my_event' );
-   ```
-4. Use a different offset from existing jobs (currently: +0 min, +30 min, +60 min) to avoid simultaneous execution.
+```php
+// Register in swh_activate():
+wp_schedule_event( time() + OFFSET_SECONDS, 'hourly', 'swh_my_event' );
+
+// Clear in swh_deactivate():
+wp_clear_scheduled_hook( 'swh_my_event' );
+
+// Hook the handler:
+add_action( 'swh_my_event', 'swh_process_my_event' );
+```
+
+Use a different offset from existing jobs (currently +0 min, +30 min, +60 min) to avoid simultaneous execution.
 
 ---
 
@@ -129,39 +159,13 @@ Never move `swh_delete_on_uninstall` or retention settings to the main form hand
 
 ---
 
-## Testing
-
-The full test suite must pass before any PR is opened or release is cut.
-
-```bash
-make test-docker   # full PHP gate inside Docker (preferred — no host PHP needed)
-make test          # full PHP gate on host (requires PHP 8.1+, semgrep)
-make e2e           # Playwright E2E suite (set WP_MODE=docker or configure SSH vars)
-make e2e-docker    # self-contained E2E: up → setup → Playwright → teardown in one command
-make coverage      # PHPUnit + pcov → coverage.xml (Clover)
-```
-
-Individual tools:
-
-| Command | Purpose |
-|---------|---------|
-| `make lint` | PHP syntax check |
-| `make phpcs` | WordPress Coding Standards (zero errors) |
-| `make phpstan` | Static analysis level 9 |
-| `make phpunit` | Unit tests |
-| `make semgrep` | SAST security scan |
-
-**MailHog email assertions:** when `MAILHOG_URL` is set and `WP_MODE=docker`, `expect_email()` calls in the E2E suite assert delivery via the MailHog API automatically. In SSH mode they fall back to the manual `EMAIL_CHECKS` summary printed at the end of the run.
-
----
-
 ## Design Tokens
 
-CSS custom properties (design tokens) are defined in `swh-shared.css`, which is loaded as a dependency of both `swh-admin.css` and `swh-frontend.css`. All tokens use the `--swh-` prefix.
+CSS custom properties are defined in `swh-shared.css`, loaded as a dependency of both `swh-admin.css` and `swh-frontend.css`. All tokens use the `--swh-` prefix.
 
 ### Token Scales (v3.5.0)
 
-**Shadow scale**
+**Shadow**
 
 | Token | Value |
 |-------|-------|
@@ -169,7 +173,7 @@ CSS custom properties (design tokens) are defined in `swh-shared.css`, which is 
 | `--swh-shadow-md` | `0 2px 6px rgba(0,0,0,0.12)` |
 | `--swh-shadow-lg` | `0 4px 12px rgba(0,0,0,0.16)` |
 
-**Z-index scale**
+**Z-index**
 
 | Token | Value | Used by |
 |-------|-------|---------|
@@ -185,14 +189,15 @@ CSS custom properties (design tokens) are defined in `swh-shared.css`, which is 
 | `--swh-ease-out` | `cubic-bezier(0,0,0.2,1)` |
 | `--swh-ease-in-out` | `cubic-bezier(0.4,0,0.2,1)` |
 
+**Dark mode:** token overrides live in a `@media (prefers-color-scheme: dark)` block in `swh-shared.css`, scoped to `.swh-helpdesk-wrapper`. This applies to the **frontend only** — do not add dark mode tokens to `swh-admin.css` (WordPress admin handles its own colour schemes).
+
 ---
 
 ## Badge System
 
-All status badges use a unified CSS component defined in `swh-shared.css`.
+All status badges use a unified component defined in `swh-shared.css`.
 
 **Base class:** `.swh-badge` — inline-block pill with padding, border-radius, and a hover transition.
-
 **Modifier classes:** `.swh-badge-{slug}` where `slug = sanitize_title($status)`.
 
 | Class | Used for |
@@ -204,7 +209,7 @@ All status badges use a unified CSS component defined in `swh-shared.css`.
 | `.swh-badge-sla-warn` | SLA warning state |
 | `.swh-badge-sla-breach` | SLA breach state |
 
-**PHP pattern** (in admin list / editor):
+**PHP pattern:**
 
 ```php
 $status_slug = sanitize_title( $status );
@@ -212,7 +217,49 @@ echo '<span class="swh-badge swh-badge-' . esc_attr( $status_slug ) . '">'
      . esc_html( $status ) . '</span>';
 ```
 
-Adding a new status automatically gets a badge modifier if a `.swh-badge-{slug}` rule exists in `swh-shared.css`. For unknown slugs only the base `.swh-badge` shape and spacing apply — no background colour or text colour is set, so those inherit from the parent context.
+---
+
+## Inbound Email Webhook
+
+The webhook endpoint is registered at `POST /wp-json/swh/v1/inbound-email`.
+
+**Authentication:** `Authorization: Bearer <swh_inbound_secret>` header.
+
+**Payload fields:**
+
+| Field | Description |
+|-------|-------------|
+| `from` | Sender email address |
+| `subject` | Email subject (must contain `[TKT-XXXX]`) |
+| `body` | Message body (lines beginning with `>` are stripped as quoted reply) |
+
+The handler extracts the ticket ID from `[TKT-XXXX]` in the subject, verifies the sender matches `_ticket_email` via `hash_equals()`, strips quoted reply lines, and inserts a new reply comment.
+
+**Docker note:** Apache strips `Authorization` headers before PHP. In Docker-based test environments, bypass HTTP entirely and call `swh_handle_inbound_email()` directly via `wp eval`.
+
+---
+
+## Testing
+
+The full test suite must pass before any PR is opened or release is cut.
+
+```bash
+make test-docker   # full PHP gate inside Docker — preferred (no host PHP needed)
+make e2e-docker    # self-contained E2E: up → setup → Playwright → teardown
+```
+
+Individual tools:
+
+| Command | Purpose |
+|---------|---------|
+| `make lint` | PHP syntax check |
+| `make phpcs` | WordPress Coding Standards (zero errors) |
+| `make phpstan` | Static analysis level 9 |
+| `make phpunit` | Unit tests |
+| `make semgrep` | SAST security scan |
+| `make coverage` | PHPUnit + pcov → `coverage.xml` (Clover) |
+
+**MailHog email assertions:** when `MAILHOG_URL` is set and `WP_MODE=docker`, `expect_email()` calls in the E2E suite assert email delivery via the MailHog API automatically.
 
 ---
 
@@ -236,4 +283,4 @@ Adding a new status automatically gets a badge modifier if a `.swh-badge-{slug}`
    git tag vX.Y.Z && git push origin vX.Y.Z
    ```
 
-   `release.yml` fires automatically on the tag push — it builds `simple-wp-helpdesk.zip` and creates the GitHub Release with the ZIP attached. No manual ZIP step required.
+   `release.yml` fires automatically on the tag push — it builds `simple-wp-helpdesk.zip` and creates the GitHub Release with the ZIP attached.

--- a/docs/development.md
+++ b/docs/development.md
@@ -85,8 +85,8 @@ The plugin uses only WordPress core data structures:
 | Tickets | `helpdesk_ticket` Custom Post Type | `_ticket_uid`, `_ticket_token`, `_ticket_status`, `_ticket_priority`, `_ticket_email`, `_ticket_attachments`, `_ticket_csat`, etc. |
 | Replies & Notes | WP Comments (`comment_type = 'helpdesk_reply'`) | `_is_internal_note`, `_is_user_reply`, `_swh_reply_orignames` |
 | Settings | `wp_options` | All keys prefixed with `swh_` |
-| Canned responses | `wp_options` | `swh_canned_responses` (JSON array) |
-| Ticket templates | `wp_options` | `swh_ticket_templates` (JSON array) |
+| Canned responses | `wp_options` | `swh_canned_responses` (PHP serialized array, stored via `update_option()`) |
+| Ticket templates | `wp_options` | `swh_ticket_templates` (PHP serialized array, stored via `update_option()`) |
 
 ### Function & Class Naming
 
@@ -229,9 +229,9 @@ The webhook endpoint is registered at `POST /wp-json/swh/v1/inbound-email`.
 
 | Field | Description |
 |-------|-------------|
-| `from` | Sender email address |
+| `sender` | Sender email address (`from` accepted as fallback) |
 | `subject` | Email subject (must contain `[TKT-XXXX]`) |
-| `body` | Message body (lines beginning with `>` are stripped as quoted reply) |
+| `body-plain` | Message body (`text` accepted as fallback; lines beginning with `>` are stripped as quoted reply) |
 
 The handler extracts the ticket ID from `[TKT-XXXX]` in the subject, verifies the sender matches `_ticket_email` via `hash_equals()`, strips quoted reply lines, and inserts a new reply comment.
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -157,8 +157,8 @@ Fires immediately before the ticket post is inserted into the database. Use this
 
 ```php
 add_action( 'swh_pre_ticket_create', function( array $data ): void {
-    // Log or validate $data before the ticket is created
-    error_log( 'New ticket incoming from: ' . $data['email'] );
+    // Log subject rather than raw email to avoid PII in logs
+    error_log( 'New ticket incoming: ' . ( $data['title'] ?? '' ) );
 } );
 ```
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,180 @@
+---
+title: Hooks Reference
+nav_order: 8
+parent: Development Guide
+---
+
+# Hooks Reference
+
+Simple WP Helpdesk exposes the following WordPress filters and actions for customization. All hooks use the `swh_` prefix.
+
+---
+
+## Filters
+
+### `swh_ticket_statuses`
+
+Modify the array of available ticket statuses.
+
+```php
+add_filter( 'swh_ticket_statuses', function( array $statuses ): array {
+    $statuses[] = 'Waiting on Client';
+    return $statuses;
+} );
+```
+
+**Parameters:** `$statuses` (array) — the current list of status strings.
+
+---
+
+### `swh_ticket_priorities`
+
+Modify the array of available ticket priorities.
+
+```php
+add_filter( 'swh_ticket_priorities', function( array $priorities ): array {
+    $priorities[] = 'Critical';
+    return $priorities;
+} );
+```
+
+**Parameters:** `$priorities` (array) — the current list of priority strings.
+
+---
+
+### `swh_allowed_file_types`
+
+Modify the array of allowed file extensions for ticket attachments.
+
+```php
+add_filter( 'swh_allowed_file_types', function( array $types ): array {
+    $types[] = 'zip';
+    $types[] = 'csv';
+    return $types;
+} );
+```
+
+**Parameters:** `$types` (array) — default: `['jpg', 'jpeg', 'jpe', 'png', 'gif', 'pdf', 'doc', 'docx', 'txt']`.
+
+---
+
+### `swh_submission_data`
+
+Filter the ticket data array immediately before the ticket post is created. Use this to add extra meta, override fields, or integrate with other plugins.
+
+```php
+add_filter( 'swh_submission_data', function( array $data ): array {
+    // Add a custom meta value derived from the submission
+    $data['my_extra_field'] = 'value';
+    return $data;
+} );
+```
+
+**Parameters:** `$data` (array) — associative array of ticket fields (name, email, title, message, priority, status, etc.).
+
+---
+
+### `swh_parse_template`
+
+Filter the fully rendered email template string after all placeholders have been replaced.
+
+```php
+add_filter( 'swh_parse_template', function( string $template, array $data ): string {
+    return str_replace( '{site_name}', get_bloginfo( 'name' ), $template );
+}, 10, 2 );
+```
+
+**Parameters:** `$template` (string) — the rendered template; `$data` (array) — the placeholder data used during rendering.
+
+---
+
+### `swh_email_headers`
+
+Modify the email headers array before any outgoing message is sent. Use this to add Reply-To, CC, or custom headers.
+
+```php
+add_filter( 'swh_email_headers', function( array $headers, string $to, string $subject ): array {
+    $headers[] = 'Reply-To: support@example.com';
+    return $headers;
+}, 10, 3 );
+```
+
+**Parameters:** `$headers` (array), `$to` (string), `$subject` (string).
+
+---
+
+### `swh_autoclose_threshold`
+
+Override the number of days after "Resolved" status before a ticket is automatically closed. Return `0` to disable auto-close entirely.
+
+```php
+add_filter( 'swh_autoclose_threshold', function( int $days ): int {
+    return 7; // override to 7 days regardless of the Settings value
+} );
+```
+
+**Parameters:** `$days` (int) — the value from Settings → General → Auto-Close Days.
+
+---
+
+### `swh_rate_limit_ttl`
+
+Override the rate limit cooldown period (in seconds) for a specific action.
+
+```php
+add_filter( 'swh_rate_limit_ttl', function( int $ttl, string $action ): int {
+    if ( 'submit' === $action ) {
+        return 60; // 60-second cooldown for new ticket submissions
+    }
+    return $ttl;
+}, 10, 2 );
+```
+
+**Parameters:** `$ttl` (int) — default TTL in seconds; `$action` (string) — the action key (e.g. `'submit'`, `'portal_reply_'`, `'portal_close_'`, `'portal_reopen_'`).
+
+---
+
+### `swh_sla_open_statuses`
+
+Modify the list of statuses considered "open" for SLA breach calculations. Tickets in any of these statuses are checked against the warn/breach thresholds by the hourly cron.
+
+```php
+add_filter( 'swh_sla_open_statuses', function( array $statuses ): array {
+    // Remove 'In Progress' from SLA tracking
+    return array_diff( $statuses, array( 'In Progress' ) );
+} );
+```
+
+**Parameters:** `$open_statuses` (array) — the current list of open status strings.
+
+---
+
+## Actions
+
+### `swh_pre_ticket_create`
+
+Fires immediately before the ticket post is inserted into the database. Use this to validate submission data or trigger external integrations.
+
+```php
+add_action( 'swh_pre_ticket_create', function( array $data ): void {
+    // Log or validate $data before the ticket is created
+    error_log( 'New ticket incoming from: ' . $data['email'] );
+} );
+```
+
+**Parameters:** `$data` (array) — the submission data array (same shape as `swh_submission_data`).
+
+---
+
+### `swh_ticket_created`
+
+Fires after a new ticket has been successfully created and all meta has been saved. The ticket ID is available and all post meta is already stored.
+
+```php
+add_action( 'swh_ticket_created', function( int $ticket_id, array $data ): void {
+    // Sync the new ticket to an external CRM
+    my_crm_create_ticket( $ticket_id, $data['email'], $data['title'] );
+}, 10, 2 );
+```
+
+**Parameters:** `$ticket_id` (int) — the WP post ID of the new ticket; `$data` (array) — the submission data array.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,86 @@
+---
+title: Home
+nav_order: 1
+description: Simple WP Helpdesk — a lightweight, full-featured ticketing system built natively for WordPress.
+permalink: /
+---
+
+# Simple WP Helpdesk
+
+<img src="https://media.seanmousseau.com/file/seanmousseau/assets/logos/swh/logo.webp" alt="Simple WP Helpdesk" width="200" style="margin-bottom: 1rem;">
+
+A lightweight, full-featured ticketing system built natively for WordPress. No third-party services, no subscriptions, no custom database tables — all data stays on your server.
+
+**Version:** 3.5.0 &nbsp;|&nbsp; **WordPress:** 5.3+ &nbsp;|&nbsp; **PHP:** 7.4+
+
+[Download Latest Release](https://github.com/seanmousseau/Simple-WP-Helpdesk/releases/latest){: .btn .btn-primary .mr-2 }
+[View on GitHub](https://github.com/seanmousseau/Simple-WP-Helpdesk){: .btn }
+
+---
+
+## Quick Start
+
+1. Download `simple-wp-helpdesk.zip` from the [latest release](https://github.com/seanmousseau/Simple-WP-Helpdesk/releases/latest).
+2. In WordPress, go to **Plugins → Add New → Upload Plugin** and install the ZIP.
+3. Activate the plugin — a **Tickets** menu appears in the dashboard.
+4. Create a WordPress page (e.g. "Support") and add the `[submit_ticket]` shortcode.
+5. Go to **Tickets → Settings → Assignment & Routing** and set **Helpdesk Page** to that page.
+
+Clients can now submit tickets and receive a secure portal link by email.
+
+---
+
+## Key Features
+
+| Feature | Details |
+|---------|---------|
+| **No custom DB tables** | Tickets are a Custom Post Type; replies are WP Comments; settings are `wp_options` |
+| **Frontend forms** | `[submit_ticket]` shortcode handles submission, portal, and ticket lookup in one page |
+| **Secure client portal** | Token-based access — clients view history, reply, upload files, close and reopen |
+| **8-tab settings panel** | General, Assignment & Routing, Email Templates, Messages, Anti-Spam, Canned Responses, Templates, Tools |
+| **14 email templates** | Fully customizable HTML + plain-text, dynamic placeholders, conditional blocks |
+| **Anti-spam** | Honeypot, Google reCAPTCHA v2, Cloudflare Turnstile |
+| **Rate limiting** | CDN/proxy-aware, persistent, per-action keys, survives cache flushes |
+| **File uploads** | XHR progress bar, drag-and-drop, proxy-served, configurable limits |
+| **Canned responses** | Save reply templates in Settings; insert from the ticket editor |
+| **Ticket templates** | Pre-configured request types that pre-fill the description field at submission |
+| **Categories taxonomy** | Hierarchical departments with admin column, list filter, and auto-assignment rules |
+| **SLA breach alerts** | Configurable warn/breach thresholds, hourly cron, row highlighting, admin digest email |
+| **Reporting dashboard** | Status breakdown, weekly trend, avg resolution time, avg first response — Chart.js |
+| **Ticket merge** | Move replies from a source ticket into a target ticket via the admin UI |
+| **Dark mode** | Full `prefers-color-scheme: dark` token overrides; force-light escape hatch |
+| **GDPR tools** | Per-email data purge, retention policies, full uninstall cleanup |
+| **Auto-updates** | GitHub-based updater — new releases appear in the WordPress dashboard |
+| **CSAT ratings** | Optional 1–5 star satisfaction prompt after ticket closure |
+| **i18n ready** | Full `.pot` file, `__()` / `esc_html__()` throughout |
+
+---
+
+## Documentation
+
+| Guide | Description |
+|-------|-------------|
+| [Installation](installation) | Install, update, and uninstall |
+| [Configuration](configuration) | All eight settings tabs explained |
+| [Usage Guide](usage) | Guide for clients and technicians |
+| [Shortcode Reference](shortcodes) | All shortcodes, attributes, and examples |
+| [Security](security) | Token auth, anti-spam, nonces, input handling |
+| [Development Guide](development) | Architecture, conventions, and release process |
+| [Hooks Reference](hooks) | PHP filters and actions for customization |
+| [Troubleshooting](troubleshooting) | Common issues and FAQ |
+
+---
+
+## Requirements
+
+| | Minimum |
+|-|---------|
+| WordPress | 5.3 |
+| PHP | 7.4 |
+
+---
+
+## License
+
+Released under the [GNU General Public License v2.0](https://www.gnu.org/licenses/gpl-2.0.html).
+Developed and maintained by [Sean Mousseau](https://github.com/seanmousseau).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,3 +1,8 @@
+---
+title: Installation
+nav_order: 2
+---
+
 # Installation
 
 ## Requirements
@@ -11,7 +16,7 @@
 
 ## Installing the Plugin
 
-Simple WP Helpdesk is not listed on the WordPress.org plugin directory. It is installed manually via ZIP upload through the WordPress dashboard.
+Simple WP Helpdesk is not listed on the WordPress.org plugin directory. Install it manually via ZIP upload through the WordPress dashboard.
 
 1. Download `simple-wp-helpdesk.zip` from the [latest GitHub release](https://github.com/seanmousseau/Simple-WP-Helpdesk/releases/latest).
 2. In your WordPress dashboard, go to **Plugins → Add New**.
@@ -27,7 +32,7 @@ A **Tickets** menu item will now appear in the left-hand dashboard sidebar.
 
 ### Combined layout (simplest)
 
-Create a single WordPress page (e.g., "Support") and add:
+Create a single WordPress page (e.g. "Support") and add:
 
 ```text
 [submit_ticket]
@@ -41,10 +46,12 @@ Create two pages:
 
 | Page | Shortcode | Purpose |
 |------|-----------|---------|
-| e.g., "Submit a Ticket" | `[submit_ticket]` | Submission form and ticket lookup |
-| e.g., "My Tickets" | `[helpdesk_portal]` | Client portal only (no submission form) |
+| e.g. "Submit a Ticket" | `[submit_ticket]` | Submission form and ticket lookup |
+| e.g. "My Tickets" | `[helpdesk_portal]` | Client portal only (no submission form) |
 
 Set **Helpdesk Page** to the portal page (`[helpdesk_portal]`). All secure portal links in emails will point there.
+
+See the [Shortcode Reference](shortcodes) for all available attributes on both shortcodes.
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,3 +1,8 @@
+---
+title: Security
+nav_order: 6
+---
+
 # Security
 
 Simple WP Helpdesk is built with WordPress security best practices. This document summarizes the key security mechanisms in place.
@@ -15,6 +20,8 @@ https://yoursite.com/support/?swh_ticket=123&token=AbCdEfGhIjKlMnOpQrSt
 - Tokens are generated with `wp_generate_password(20, false)` — 20 random alphanumeric characters.
 - Token comparisons always use `hash_equals()` to prevent timing-based brute-force attacks.
 - Tokens are stored as post meta and never exposed in the admin-facing ticket list.
+- Empty tokens are rejected before comparison (prevents `hash_equals('', '')` bypass).
+- Tokens have a configurable expiration TTL (default 90 days) and auto-rotate on lookup.
 
 ---
 
@@ -28,6 +35,8 @@ Three methods are available (configured in **Settings → Anti-Spam**):
 | **Google reCAPTCHA v2** | Server-side verification with Google's API before ticket submission is accepted |
 | **Cloudflare Turnstile** | Privacy-friendly challenge verified server-side before processing |
 
+Protection applies to the submission form, ticket lookup form, and portal reply/close/reopen forms.
+
 ---
 
 ## Frontend Rate Limiting
@@ -35,6 +44,8 @@ Three methods are available (configured in **Settings → Anti-Spam**):
 All frontend form actions (ticket submission, reply, close, re-open) enforce a **30-second cooldown** per action per client IP. Limits are stored in `wp_options` (not transients) so they survive object-cache flushes and work correctly across load-balanced environments.
 
 Each portal action type has its own rate limit key (`portal_close_`, `portal_reopen_`, `portal_reply_`), so closing a ticket does not block an immediate reopen attempt.
+
+IP detection uses `swh_get_client_ip()`, which inspects `HTTP_X_FORWARDED_FOR` and `HTTP_X_REAL_IP` headers (in addition to `REMOTE_ADDR`) and is CDN/proxy-aware.
 
 ---
 
@@ -77,7 +88,7 @@ All user input is sanitized on the way in and escaped on the way out:
 ## File Upload Security
 
 - File uploads are processed exclusively through WordPress's `wp_handle_upload()`.
-- **Allowed MIME types:** JPEG, PNG, GIF, PDF, DOC, DOCX, TXT.
+- **Allowed MIME types:** JPEG, PNG, GIF, PDF, DOC, DOCX, TXT. Extendable via the `swh_allowed_file_types` filter.
 - Upload size is enforced both client-side (JavaScript) and server-side (PHP).
 - Files are stored in a dedicated `/swh-helpdesk/` subdirectory inside the WordPress uploads folder, protected by an `.htaccess` file that denies all direct access.
 - Files are never served by direct URL — all downloads go through `swh_serve_file()`, which verifies the portal token before streaming the file.
@@ -88,6 +99,17 @@ All user input is sanitized on the way in and escaped on the way out:
 ## Assignee Validation
 
 When saving a ticket, the assigned user ID is verified to belong to either the `administrator` or `technician` role. Invalid user IDs are silently discarded, preventing privilege escalation via forged form submissions.
+
+---
+
+## Inbound Webhook Authentication
+
+The reply-by-email endpoint (`POST /wp-json/swh/v1/inbound-email`) requires:
+
+1. A valid `Authorization: Bearer <token>` header matching the `swh_inbound_secret` option.
+2. The sender email address must match the `_ticket_email` meta on the target ticket (verified via `hash_equals()`).
+
+This prevents unauthorized parties from injecting replies into tickets.
 
 ---
 

--- a/docs/shortcodes.md
+++ b/docs/shortcodes.md
@@ -1,0 +1,85 @@
+---
+title: Shortcode Reference
+nav_order: 5
+---
+
+# Shortcode Reference
+
+Simple WP Helpdesk provides two shortcodes. Both are handled by the same underlying function and share the same attribute set.
+
+---
+
+## `[submit_ticket]`
+
+Renders the full helpdesk interface on a single page: ticket submission form, ticket lookup, and the client portal (when a valid token is present in the URL).
+
+This is the recommended shortcode for most sites. Use it on a single "Support" page.
+
+```text
+[submit_ticket]
+```
+
+---
+
+## `[helpdesk_portal]`
+
+Renders only the client portal and ticket lookup — without the submission form. Use this on a dedicated "My Tickets" or "Support Hub" page when you want to keep the submission form on a separate page.
+
+```text
+[helpdesk_portal]
+```
+
+---
+
+## Shared Attributes
+
+Both shortcodes accept the following attributes:
+
+| Attribute | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `show_priority` | `yes` / `no` | `yes` | Show or hide the Priority field on the submission form |
+| `default_priority` | Any configured priority label | Site default | Pre-select a specific priority on the submission form |
+| `default_status` | Any configured status label | Site default | Override the status assigned to new tickets from this page |
+| `show_lookup` | `yes` / `no` | `yes` | Show or hide the "Resend my ticket links" lookup form toggle |
+
+### Examples
+
+Hide the priority field and default to "High":
+
+```text
+[submit_ticket show_priority="no" default_priority="High"]
+```
+
+Show a submission form that always creates tickets as "In Progress":
+
+```text
+[submit_ticket default_status="In Progress"]
+```
+
+Portal page without the lookup form:
+
+```text
+[helpdesk_portal show_lookup="no"]
+```
+
+---
+
+## How Portal URLs Work
+
+When a client clicks the secure link in their email, the URL contains two query parameters:
+
+```text
+https://yoursite.com/support/?swh_ticket=123&token=AbCdEfGhIjKlMnOpQrSt
+```
+
+The shortcode detects these parameters and renders the client portal instead of the submission form. The **Helpdesk Page** setting (**Tickets → Settings → Assignment & Routing**) controls which page these links point to.
+
+If neither parameter is present:
+- Logged-in WordPress users see the **My Tickets** dashboard (a card list of their open tickets).
+- Guests see the **Resend my ticket links** lookup form (unless `show_lookup="no"`).
+
+---
+
+## Compatibility
+
+Both shortcodes are wrapped in `.swh-helpdesk-wrapper` for scoped CSS and are compatible with Elementor, Divi, Beaver Builder, and other page builders. Place the shortcode in a standard HTML/Shortcode block.

--- a/docs/shortcodes.md
+++ b/docs/shortcodes.md
@@ -75,8 +75,8 @@ https://yoursite.com/support/?swh_ticket=123&token=AbCdEfGhIjKlMnOpQrSt
 The shortcode detects these parameters and renders the client portal instead of the submission form. The **Helpdesk Page** setting (**Tickets → Settings → Assignment & Routing**) controls which page these links point to.
 
 If neither parameter is present:
-- Logged-in WordPress users see the **My Tickets** dashboard (a card list of their open tickets).
-- Guests see the **Resend my ticket links** lookup form (unless `show_lookup="no"`).
+- Logged-in WordPress users see the **My Tickets** dashboard — a card list of all tickets whose `_ticket_email` meta matches the logged-in user's email address.
+- Guests see the lookup form rendered by `swh_render_lookup_form()` (unless `show_lookup="no"`).
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -56,6 +56,7 @@ Tokens also rotate automatically on each lookup. If a client bookmarks a link, i
 ## Auto-close is not running
 
 1. WordPress cron requires traffic to trigger. On low-traffic sites, use a real cron job:
+
    ```bash
    */5 * * * * curl -s "https://yoursite.com/wp-cron.php?doing_wp_cron" > /dev/null
    ```
@@ -84,10 +85,13 @@ Tokens also rotate automatically on each lookup. If a client bookmarks a link, i
 
 1. Confirm the `Authorization: Bearer <token>` header matches the value stored in **Settings → Assignment & Routing → Inbound Secret**.
 2. Apache may strip the `Authorization` header. Add to `.htaccess`:
+
    ```apache
    SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
    ```
+
    Or in `wp-config.php`:
+
    ```php
    $_SERVER['HTTP_AUTHORIZATION'] = $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ?? '';
    ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,134 @@
+---
+title: Troubleshooting
+nav_order: 9
+---
+
+# Troubleshooting
+
+---
+
+## Clients are not receiving email notifications
+
+1. **Check WordPress mail delivery.** Many hosts block `wp_mail()` by default. Install a plugin like WP Mail SMTP and configure it with a transactional mail service (Mailgun, SendGrid, Postmark, SES).
+2. **Check the Fallback Alert Email.** Go to **Tickets → Settings → Assignment & Routing** and ensure a **Fallback Alert Email** is set in case no assignee is configured.
+3. **Check spam folders.** Emails from `wp_mail()` with default configuration often land in spam.
+4. **Use the Send Test Email button.** In **Settings → Email Templates**, click **Send Test Email** to verify delivery is working at all.
+
+---
+
+## Portal links in emails lead to a blank page or wrong page
+
+1. Go to **Tickets → Settings → Assignment & Routing**.
+2. Make sure **Helpdesk Page** is set to the page containing `[submit_ticket]` or `[helpdesk_portal]`.
+3. If the setting is correct but links still go to the wrong page, check whether the page has been moved or its permalink structure changed. Re-saving the setting regenerates future links.
+
+> **Note:** Portal links are generated at the time the ticket is created. Changing **Helpdesk Page** after the fact only affects new tickets. Existing ticket links stored in `_ticket_url` post meta continue to point to the original page.
+
+---
+
+## The ticket submission form is not appearing
+
+1. Confirm the page contains `[submit_ticket]` and that the shortcode is not wrapped in HTML that prevents rendering.
+2. Check for JavaScript errors in the browser console — a conflicting plugin may be breaking the page.
+3. If using a page builder (Elementor, Divi, etc.), paste the shortcode inside a **Shortcode** block, not a text/HTML widget.
+
+---
+
+## Clients see "Invalid or expired token" when clicking their portal link
+
+Portal tokens expire after 90 days by default. When a token expires:
+- The client is shown an error page with a direct link to the ticket lookup form.
+- Entering their email on the lookup form resends fresh portal links.
+
+Tokens also rotate automatically on each lookup. If a client bookmarks a link, it may become stale after their next visit.
+
+---
+
+## File uploads are failing
+
+1. Check **Settings → General → Max Upload Size** — the PHP `upload_max_filesize` and `post_max_size` ini values must be at least as large.
+2. Confirm the WordPress uploads directory is writable: `wp-content/uploads/swh-helpdesk/`.
+3. Check the browser console for JavaScript errors during upload.
+4. The default allowed types are: jpg, jpeg, png, gif, pdf, doc, docx, txt. Use the [`swh_allowed_file_types`](hooks#swh_allowed_file_types) filter to extend this list.
+
+---
+
+## Auto-close is not running
+
+1. WordPress cron requires traffic to trigger. On low-traffic sites, use a real cron job:
+   ```bash
+   */5 * * * * curl -s "https://yoursite.com/wp-cron.php?doing_wp_cron" > /dev/null
+   ```
+2. Verify **Auto-Close Days** in **Settings → General** is set to a value greater than `0`.
+3. Confirm the configured **Resolved Status** matches a status in your **Ticket Statuses** list exactly (case-sensitive).
+
+---
+
+## SLA breaches are not being flagged
+
+1. Confirm **SLA Warn Hours** and/or **SLA Breach Hours** in **Settings → General** are set to values greater than `0`.
+2. The SLA cron (`swh_sla_check_event`) runs hourly. The first check runs up to one hour after plugin activation.
+3. Open tickets must be in a status listed in `swh_sla_open_statuses` to be evaluated. Use the [`swh_sla_open_statuses`](hooks#swh_sla_open_statuses) filter to inspect or modify this list.
+
+---
+
+## The anti-spam widget is not showing on the frontend form
+
+1. For **reCAPTCHA v2** and **Turnstile**, confirm both the Site Key and Secret Key are saved in **Settings → Anti-Spam**.
+2. Check for Content Security Policy (CSP) headers on your site that may be blocking scripts from `google.com` or `challenges.cloudflare.com`.
+3. The widget only renders on the submission form, lookup form, and portal reply form — not on other pages.
+
+---
+
+## The inbound email webhook returns 401
+
+1. Confirm the `Authorization: Bearer <token>` header matches the value stored in **Settings → Assignment & Routing → Inbound Secret**.
+2. Apache may strip the `Authorization` header. Add to `.htaccess`:
+   ```apache
+   SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
+   ```
+   Or in `wp-config.php`:
+   ```php
+   $_SERVER['HTTP_AUTHORIZATION'] = $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ?? '';
+   ```
+
+---
+
+## Rate limiting is blocking legitimate users
+
+The default cooldown is 30 seconds per action per IP. On sites behind a load balancer or CDN that sends a shared IP, all users may share one rate limit bucket.
+
+Use the [`swh_rate_limit_ttl`](hooks#swh_rate_limit_ttl) filter to reduce the TTL, or inspect `wp_options` rows with the prefix `swh_rl_` to identify which IPs are being throttled.
+
+---
+
+## The Reporting dashboard shows no data
+
+Report data is cached for one hour. On a fresh install with no tickets, the charts will be empty. Once tickets exist and the cache expires, data will appear.
+
+If data is present but charts are blank, check the browser console for JavaScript errors — Chart.js may have failed to load.
+
+---
+
+## Frequently Asked Questions
+
+**Does this plugin create custom database tables?**
+No. Simple WP Helpdesk uses WordPress core data structures exclusively — custom post types, comments, post meta, comment meta, and options.
+
+**Can I use it with a multisite network?**
+The plugin is designed for single-site use. It has not been tested in a network/multisite configuration.
+
+**Can clients view and reply to tickets without a WordPress account?**
+Yes. The client portal is entirely token-based. No WordPress account is required to view, reply to, close, or reopen a ticket.
+
+**Does it work with page builders?**
+Yes. The shortcodes are scoped under `.swh-helpdesk-wrapper` for compatibility with Elementor, Divi, Beaver Builder, and others. Use a Shortcode block.
+
+**Can I add more file types for uploads?**
+Yes. Use the [`swh_allowed_file_types`](hooks#swh_allowed_file_types) filter to add extensions. MIME validation is handled by WordPress's `wp_handle_upload()`.
+
+**Can technicians be restricted to only their assigned tickets?**
+Yes. Enable **Restrict Technicians** in **Settings → General**. Technicians will only see tickets assigned to them. Admins always see all tickets.
+
+**How do I report a security vulnerability?**
+Use [GitHub Security Advisories](https://github.com/seanmousseau/Simple-WP-Helpdesk/security/advisories/new) to report privately. Do not open a public issue for security concerns.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -49,7 +49,7 @@ Tokens also rotate automatically on each lookup. If a client bookmarks a link, i
 1. Check **Settings → General → Max Upload Size** — the PHP `upload_max_filesize` and `post_max_size` ini values must be at least as large.
 2. Confirm the WordPress uploads directory is writable: `wp-content/uploads/swh-helpdesk/`.
 3. Check the browser console for JavaScript errors during upload.
-4. The default allowed types are: jpg, jpeg, png, gif, pdf, doc, docx, txt. Use the [`swh_allowed_file_types`](hooks#swh_allowed_file_types) filter to extend this list.
+4. The default allowed types are: jpg, jpeg, jpe, png, gif, pdf, doc, docx, txt. Use the [`swh_allowed_file_types`](hooks#swh_allowed_file_types) filter to extend this list.
 
 ---
 
@@ -60,6 +60,7 @@ Tokens also rotate automatically on each lookup. If a client bookmarks a link, i
    ```bash
    */5 * * * * curl -s "https://yoursite.com/wp-cron.php?doing_wp_cron" > /dev/null
    ```
+
 2. Verify **Auto-Close Days** in **Settings → General** is set to a value greater than `0`.
 3. Confirm the configured **Resolved Status** matches a status in your **Ticket Statuses** list exactly (case-sensitive).
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,3 +1,8 @@
+---
+title: Usage Guide
+nav_order: 4
+---
+
 # Usage Guide
 
 ---
@@ -8,8 +13,9 @@
 
 1. Go to the Support page on the website.
 2. Fill in your **Name**, **Email**, **Priority**, **Summary** (title), and **Description**.
-3. Optionally click **Choose Files** to attach screenshots or documents.
-4. Click **Submit Ticket**.
+3. If ticket templates are configured, select a **Request Type** to pre-fill the description.
+4. Optionally click **Choose Files** (or drag and drop) to attach screenshots or documents.
+5. Click **Submit Ticket**.
 
 You will receive an email confirmation containing a secure tracking link unique to your ticket.
 
@@ -21,7 +27,7 @@ You will receive an email confirmation containing a secure tracking link unique 
 
 ### My Tickets Dashboard
 
-If you visit the helpdesk portal page without a ticket link and are logged in to WordPress, you will see a table of your open tickets with direct links. If you are not logged in, you will see the **Resend my ticket links** lookup form — enter your email address to have your secure links resent.
+If you visit the helpdesk portal page without a ticket link and are logged in to WordPress, you will see a card-based list of your open tickets with direct links. If you are not logged in, you will see the **Resend my ticket links** lookup form — enter your email address to have your secure links resent.
 
 ### Closing a Ticket
 
@@ -43,35 +49,93 @@ If a ticket is **Closed** but your issue is unresolved, the standard reply form 
 2. The ticket list shows all tickets with their status, priority, and assignee.
 3. Click a ticket title to open the Ticket Editor.
 
+**Filtering and sorting:** Use the filter dropdowns above the list to narrow by status, priority, assignee, or category. Column headers (Status, Priority, Date) are clickable for sorting. A blue dot marks tickets with unread client replies.
+
+**Bulk status change:** Check multiple tickets and use the **Bulk Actions** dropdown to set them all to any configured status in one action.
+
 ### Updating Ticket Details
 
-The **Ticket Details** sidebar (right-hand side) contains:
+The **Ticket Details** panel (right-hand side) contains:
 - Client name and email
 - Assignee dropdown
-- Priority dropdown
-- Status dropdown
+- Priority and Status dropdowns
+- Category assignment
 - Links to all attached files
 
-After making changes, click the blue **Update** button at the top-right to save.
+After making changes, click **Update** at the top-right to save.
 
 ### Public Replies
 
 1. Scroll down to the **Conversation & Reply** section.
-2. Type your reply in the left-hand text box. Attach files if needed.
-3. Click **Update** to save and send the reply to the client.
+2. Type your reply in the **Reply** text box. Attach files if needed.
+3. Click **Send Reply** (or the main **Update** button) to save and email the reply to the client.
 
 > **Tip:** If you change the status to Resolved or Closed at the same time as sending a reply, the system sends a single combined email rather than two separate notifications.
 
 ### Internal Notes
 
-Type in the **yellow** right-hand box to leave an internal note. Internal notes are visible only to logged-in technicians — clients never see them and receive no email notification.
+Type in the **Internal Note** box to leave a note visible only to logged-in technicians. Internal notes appear in the conversation thread with a distinct yellow background. Clients never see them and receive no email notification.
+
+### Canned Responses
+
+If canned responses are configured in **Settings → Canned Responses**, a **Canned Response** picker appears in the ticket editor. Click it, select a template, and its body is inserted into the active reply or note field.
 
 ### Creating Tickets on Behalf of Clients
 
 1. Go to **Tickets → Add New**.
 2. Enter the ticket **Title** (summary) and **Description** in the standard post editor.
-3. In the **Ticket Details** sidebar, enter the client's **Name** and **Email**.
+3. In the **Ticket Details** panel, enter the client's **Name** and **Email**.
 4. Check **Send confirmation email to client** if you want the client to receive their portal link immediately.
-5. Set the desired **Priority** and **Status**, then click **Publish**.
+5. Set the desired **Priority**, **Status**, and **Category**, then click **Publish**.
 
-The ticket UID, secure token, and portal URL are auto-generated on the first save. The portal URL is based on the **Helpdesk Page** configured in **Settings → Assignment & Routing**.
+The ticket UID, secure token, and portal URL are auto-generated on the first save.
+
+### Categories / Departments
+
+Assign one or more **Categories** to a ticket using the category meta box in the ticket editor. Categories are hierarchical, appear as a column in the ticket list, and can be used as a filter criterion.
+
+Configure categories at **Tickets → Categories**. Auto-assignment rules (in **Settings → Assignment & Routing**) can automatically assign tickets to specific technicians based on category.
+
+### SLA Monitoring
+
+When SLA thresholds are configured (**Settings → General → SLA Warn/Breach Hours**), the hourly cron check flags tickets that have been open beyond the thresholds:
+
+| State | Visual indicator |
+|-------|-----------------|
+| **SLA Warning** | Yellow `.swh-badge-sla-warn` badge on the ticket |
+| **SLA Breach** | Red `.swh-badge-sla-breach` badge on the ticket |
+
+An admin digest email is sent when tickets breach the SLA threshold.
+
+### Ticket Merge
+
+If a client submits a duplicate ticket, you can merge it into the original:
+
+1. Open the ticket you want to **remove** (the source/duplicate).
+2. Scroll to the **Merge Ticket** section in the ticket editor.
+3. Enter the **Target Ticket ID** (the ticket to keep all replies on).
+4. Click **Merge**. All replies from the source ticket are moved to the target; the source ticket is then closed.
+
+### Reporting Dashboard
+
+Go to **Tickets → Reports** to view the reporting dashboard:
+
+| Report | Description |
+|--------|-------------|
+| **KPI Cards** | Total tickets, Open tickets, Avg resolution time, Avg first response time |
+| **Status Breakdown** | Doughnut chart showing ticket counts by status |
+| **Weekly Trend** | Bar chart of ticket volume over the past 7 days |
+| **Avg Resolution Time** | Average time from ticket creation to resolution |
+| **Avg First Response** | Average time from ticket creation to first staff reply |
+
+Report data is cached for one hour. The KPI cards load asynchronously after page load.
+
+### Inbound Email Webhook
+
+Replies sent to a dedicated address can be forwarded to the plugin's inbound webhook at:
+
+```
+POST /wp-json/swh/v1/inbound-email
+```
+
+See the [Developer Guide](development#inbound-email-webhook) for setup details.

--- a/simple-wp-helpdesk/admin/class-plugin-action-links.php
+++ b/simple-wp-helpdesk/admin/class-plugin-action-links.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Plugin action links shown under the plugin name on the Plugins list page.
+ *
+ * @package Simple_WP_Helpdesk
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_filter( 'plugin_action_links_' . plugin_basename( SWH_PLUGIN_FILE ), 'swh_plugin_action_links' );
+
+/**
+ * Appends Settings and Documentation links under the plugin name on the Plugins page.
+ *
+ * @param string[] $links Existing action links.
+ * @return string[]
+ */
+function swh_plugin_action_links( array $links ): array {
+	$settings_url = admin_url( 'edit.php?post_type=helpdesk_ticket&page=swh-settings' );
+	$docs_url     = 'https://seanmousseau.github.io/Simple-WP-Helpdesk/';
+	array_unshift(
+		$links,
+		'<a href="' . esc_url( $settings_url ) . '">' . esc_html__( 'Settings', 'simple-wp-helpdesk' ) . '</a>',
+		'<a href="' . esc_url( $docs_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Docs', 'simple-wp-helpdesk' ) . '</a>'
+	);
+	return $links;
+}

--- a/simple-wp-helpdesk/simple-wp-helpdesk.php
+++ b/simple-wp-helpdesk/simple-wp-helpdesk.php
@@ -40,6 +40,7 @@ if ( is_admin() ) {
 	require_once SWH_PLUGIN_DIR . 'admin/class-ticket-list.php';
 	require_once SWH_PLUGIN_DIR . 'admin/class-reporting.php';
 	require_once SWH_PLUGIN_DIR . 'admin/class-reporting-ui.php';
+	add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), 'swh_plugin_action_links' );
 }
 
 // Frontend includes.
@@ -159,8 +160,6 @@ function swh_inject_plugin_icons_into_update_transient( $transient ) {
 	return $transient;
 }
 
-// Add "Settings" and "Docs" links on the Plugins list screen.
-add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), 'swh_plugin_action_links' );
 /**
  * Appends Settings and Documentation links under the plugin name on the Plugins page.
  *

--- a/simple-wp-helpdesk/simple-wp-helpdesk.php
+++ b/simple-wp-helpdesk/simple-wp-helpdesk.php
@@ -40,7 +40,7 @@ if ( is_admin() ) {
 	require_once SWH_PLUGIN_DIR . 'admin/class-ticket-list.php';
 	require_once SWH_PLUGIN_DIR . 'admin/class-reporting.php';
 	require_once SWH_PLUGIN_DIR . 'admin/class-reporting-ui.php';
-	add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), 'swh_plugin_action_links' );
+	require_once SWH_PLUGIN_DIR . 'admin/class-plugin-action-links.php';
 }
 
 // Frontend includes.
@@ -158,23 +158,6 @@ function swh_inject_plugin_icons_into_update_transient( $transient ) {
 		}
 	}
 	return $transient;
-}
-
-/**
- * Appends Settings and Documentation links under the plugin name on the Plugins page.
- *
- * @param string[] $links Existing action links.
- * @return string[]
- */
-function swh_plugin_action_links( array $links ): array {
-	$settings_url = admin_url( 'edit.php?post_type=helpdesk_ticket&page=swh-settings' );
-	$docs_url     = 'https://seanmousseau.github.io/Simple-WP-Helpdesk/';
-	array_unshift(
-		$links,
-		'<a href="' . esc_url( $settings_url ) . '">' . esc_html__( 'Settings', 'simple-wp-helpdesk' ) . '</a>',
-		'<a href="' . esc_url( $docs_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Docs', 'simple-wp-helpdesk' ) . '</a>'
-	);
-	return $links;
 }
 
 // ==============================================================================

--- a/simple-wp-helpdesk/simple-wp-helpdesk.php
+++ b/simple-wp-helpdesk/simple-wp-helpdesk.php
@@ -118,7 +118,7 @@ function swh_plugin_description_html() {
 		/* translators: %s: wp_options WordPress table name wrapped in <code> tags */
 		array( __( 'CDN/proxy-aware rate limiting', 'simple-wp-helpdesk' ), sprintf( __( 'persistent via %s, survives cache flushes', 'simple-wp-helpdesk' ), '<code>wp_options</code>' ) ),
 		array( __( 'Token expiration', 'simple-wp-helpdesk' ), __( 'configurable TTL with auto-rotation for portal links', 'simple-wp-helpdesk' ) ),
-		array( __( 'Tabbed settings panel', 'simple-wp-helpdesk' ), __( '7 tabs: General, Assignment &amp; Routing, Email Templates, Messages, Anti-Spam, Canned Responses, Tools', 'simple-wp-helpdesk' ) ),
+		array( __( 'Tabbed settings panel', 'simple-wp-helpdesk' ), __( '8 tabs: General, Assignment &amp; Routing, Email Templates, Messages, Anti-Spam, Canned Responses, Templates, Tools', 'simple-wp-helpdesk' ) ),
 		array( __( 'GDPR tools', 'simple-wp-helpdesk' ), __( 'per-email data purge, retention policies, and thorough uninstall cleanup', 'simple-wp-helpdesk' ) ),
 		array( __( 'Internationalization', 'simple-wp-helpdesk' ), __( 'i18n ready with full text-domain support', 'simple-wp-helpdesk' ) ),
 		array( __( 'GitHub auto-updater', 'simple-wp-helpdesk' ), __( 'new releases delivered directly to the WordPress dashboard via plugin-update-checker', 'simple-wp-helpdesk' ) ),
@@ -157,6 +157,25 @@ function swh_inject_plugin_icons_into_update_transient( $transient ) {
 		}
 	}
 	return $transient;
+}
+
+// Add "Settings" and "Docs" links on the Plugins list screen.
+add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), 'swh_plugin_action_links' );
+/**
+ * Appends Settings and Documentation links under the plugin name on the Plugins page.
+ *
+ * @param string[] $links Existing action links.
+ * @return string[]
+ */
+function swh_plugin_action_links( array $links ): array {
+	$settings_url = admin_url( 'edit.php?post_type=helpdesk_ticket&page=swh-settings' );
+	$docs_url     = 'https://seanmousseau.github.io/Simple-WP-Helpdesk/';
+	array_unshift(
+		$links,
+		'<a href="' . esc_url( $settings_url ) . '">' . esc_html__( 'Settings', 'simple-wp-helpdesk' ) . '</a>',
+		'<a href="' . esc_url( $docs_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Docs', 'simple-wp-helpdesk' ) . '</a>'
+	);
+	return $links;
 }
 
 // ==============================================================================


### PR DESCRIPTION
## Summary

- Set up Jekyll GitHub Pages site (just-the-docs theme) at `https://seanmousseau.github.io/Simple-WP-Helpdesk/`
- Fixed accuracy issues across all existing docs (version, tab counts, repo structure, missing features)
- Added three new reference pages: Shortcodes, Hooks, Troubleshooting
- Added Settings + Docs action links to the WordPress Plugins page

## Changes

### New files
- `docs/_config.yml` — Jekyll config (just-the-docs theme, logo, GitHub edit links)
- `docs/index.md` — site homepage with quick start, full feature table, nav links
- `docs/shortcodes.md` — complete `[submit_ticket]` + `[helpdesk_portal]` attribute reference
- `docs/hooks.md` — all 9 filters + 2 actions with code examples (child of Development Guide)
- `docs/troubleshooting.md` — 10 common issues + FAQ

### Updated docs
- `README.md` — version 2.0.0 → 3.5.0; feature list updated to reflect all v3.x additions; links now point to GitHub Pages
- `docs/configuration.md` — tab count 6 → 8; added Canned Responses and Templates tabs
- `docs/development.md` — repo structure updated (reporting files, Makefile, docker/); Inbound Email Webhook section added
- `docs/usage.md` — technician section expanded with categories, SLA, ticket merge, reporting, canned responses, bulk actions
- `docs/security.md` — token empty-value rejection, inbound webhook auth, MIME type filter note added

### Plugin
- `simple-wp-helpdesk.php` — `swh_plugin_action_links()` adds Settings + Docs links on the Plugins page; fixed tab count string (7 → 8)

## Test plan

- [ ] Gate: `make test-docker` passes (lint ✓ PHPCS ✓ PHPStan ✓ PHPUnit 52/52 ✓ Semgrep ✓)
- [ ] GitHub Pages builds at `https://seanmousseau.github.io/Simple-WP-Helpdesk/` after merge
- [ ] Plugins page shows Settings and Docs links under Simple WP Helpdesk
- [ ] All docs navigation renders correctly in just-the-docs (Home → Installation → … → Troubleshooting)
- [ ] Hooks page appears as child of Development Guide in sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * v3.5.0: My Tickets dashboard, category taxonomy with filtering/auto-assignment, SLA warnings/breach alerts, ticket merge, reporting & KPI dashboards, optional CSAT, Templates and Canned Responses tabs, unified design tokens, full dark mode, improved multi-file upload (drag‑and‑drop + progress), persistent per-action rate-limiting keys, inbound email webhook (Bearer auth).

* **Documentation**
  * Published GitHub Pages docs with Quick Links, Shortcode & Hooks references, Troubleshooting/FAQ, i18n (.pot) notes, install/usage updates, and Plugins-page "Settings" & "Docs" links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->