### PR TITLE
docs(internal): living roadmap, parked, and discussion docs + v3.7 foundations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ starting from the next release after 1.8.
 - GitHub Pages documentation site at `https://seanmousseau.github.io/Simple-WP-Helpdesk/` (Jekyll, just-the-docs theme) — covers all features through v3.5.0.
 - New docs pages: Shortcode Reference, Hooks Reference (all 9 filters + 2 actions with examples), Troubleshooting / FAQ.
 - Plugins page action links: **Settings** and **Docs** shortcuts shown under the plugin name.
+- Internal planning docs under `docs/internal/`: living v3.x and v4.x release roadmaps, parked-features registry (Zapier app parked), and new-features discussion log. Establishes a v3.7.0 "v4 Foundations" milestone covering non-breaking primitives that de-risk v4.0/v4.1 (lifecycle action hooks moved earlier, `swh_get_option()` helper, deprecation helper, JS architecture spike, PSR-4 autoload, component inventory, performance baseline).
 
 ### Changed
 

--- a/docs/internal/new_features_discussion.md
+++ b/docs/internal/new_features_discussion.md
@@ -1,0 +1,109 @@
+# New Features — Discussion (living document)
+
+Ideas not currently on any roadmap. Each entry is a starting point for discussion, **not** a commitment. Things move from here → a roadmap milestone once shaped, prioritized, and accepted.
+
+Last updated: 2026-05-04
+
+---
+
+## How to use this doc
+
+1. **Add anything** — half-formed ideas welcome. Worse to lose them than to keep a messy list.
+2. **Each entry has the same skeleton** — problem, sketch, signals, open questions, fit. Skeleton = forces the idea into honest shape.
+3. **Once an idea is shaped enough** — open a GitHub issue, attach to a milestone, remove from this doc.
+4. **Once an idea is rejected** — move to `parked_features.md` with the reasoning.
+
+---
+
+## Active discussion
+
+### 1. AI-assisted reply suggestions
+- **Problem:** Technicians retype the same answer often. Canned responses help but require manual creation/maintenance.
+- **Sketch:** Per-ticket "Suggest reply" button → calls a configurable LLM endpoint (BYO API key — OpenAI / Anthropic / local Ollama) with redacted ticket context. Returns a draft, never auto-sends. Could optionally suggest categories + priority.
+- **Signals:** Industry baseline now (Zendesk AI, Intercom Fin, HubSpot ChatSpot). Self-hosted users want privacy → BYO key + local-LLM support is the differentiator vs SaaS.
+- **Open questions:** PII redaction policy. Cost gating (per-user / per-ticket budget). Where prompts live (filterable code vs admin UI). Audit logging.
+- **Roadmap fit:** v4.4+ (after REST + webhooks land — sits naturally on top of the API surface).
+
+### 2. Macros / automation rules
+- **Problem:** Today only assignment rules and SLA cron run automatically. Common asks: "after 24h with no client reply → close", "if priority=urgent and unassigned → notify lead", "if subject contains 'invoice' → tag billing + assign Cathy."
+- **Sketch:** Rules engine with WHEN (event/condition) → THEN (action) blocks. Reuses v4.1 event hooks. Admin UI is the hard part.
+- **Signals:** Top-3 ask in any helpdesk forum thread. Assignment rules already prove the pattern works.
+- **Open questions:** Condition DSL (visual builder vs JSON). Conflict resolution when multiple rules match. Loop prevention (rule can't trigger another rule that triggers itself).
+- **Roadmap fit:** v4.4 or v5.0 — depends on v4.1 event hooks being live.
+
+### 3. Tags (separate from categories)
+- **Problem:** Categories are hierarchical, slow to apply, and one-per-ticket in practice. Real-world triage wants quick, freeform, multi-value tagging ("vip", "needs-screenshot", "billing-related").
+- **Sketch:** New non-hierarchical taxonomy (`helpdesk_tag`). Inline tag input on the ticket editor. Filter chips on the inbox.
+- **Signals:** Categories taxonomy added in v3.0 already feels like the wrong shape for triage workflows.
+- **Open questions:** Migration path from category-as-tag patterns. Tag autocomplete UX. Bulk tagging.
+- **Roadmap fit:** Pairs with v4.0 inbox redesign. Could land as v4.0 or v4.1.
+
+### 4. Knowledge base / FAQ shortcode
+- **Problem:** Same questions get asked repeatedly. No first-line deflection mechanism.
+- **Sketch:** New CPT `helpdesk_kb`. `[helpdesk_kb]` shortcode. On the submission form, real-time search ("did you mean: …") before the user submits. Optionally feeds AI suggestions (#1).
+- **Signals:** Strong correlation between "good helpdesk" and "good KB" — companies that get this right have 30–50% deflection.
+- **Open questions:** Compete with WP's existing KB plugins (BetterDocs, Heroic KB)? Or stay minimal and integrate?
+- **Roadmap fit:** v5.x — too big for any current milestone.
+
+### 5. CSAT trend reporting
+- **Problem:** v3.0 added CSAT capture (`_ticket_csat`). No reporting on it. Captured data, never shown.
+- **Sketch:** New report card on Reports page — average CSAT, trend over time, breakdown by assignee. Sits next to existing reports.
+- **Signals:** Cheap win — data already exists, just needs a chart. Likely a v3.7.0 candidate if v3.x continues.
+- **Open questions:** Per-assignee privacy concerns (does a tech want their CSAT visible to others?). Sample size minimums.
+- **Roadmap fit:** v3.7 (small, non-breaking) **or** roll into v4.0 reports redesign ([#359](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/359)).
+
+### 6. Time tracking on tickets
+- **Problem:** Agencies and MSPs running this as a billable-hours tool ask for time tracking constantly.
+- **Sketch:** Start/stop timer per ticket. Manual entry. Total time meta. Export to CSV. Optional integration with billing plugins (WooCommerce, FreshBooks).
+- **Signals:** Heard 3× from agency users. Real demand exists, but it's a feature segment, not the core use case.
+- **Open questions:** Scope creep risk — once you have time tracking, you get asked for invoicing, rate cards, project budgets. Where do we draw the line?
+- **Roadmap fit:** v5.x or never. Could also be a separate companion plugin.
+
+### 7. Customer organizations / firms
+- **Problem:** Users at the same company are tracked as individuals. No way to see "all tickets from Acme Corp" or set per-company SLAs.
+- **Sketch:** New CPT `helpdesk_org`. Tickets link to org via meta. Per-org SLA override. Org-scoped portal view ("see all tickets from your team").
+- **Signals:** B2B helpdesk pattern. Adds significant data model complexity.
+- **Open questions:** Auto-detect from email domain? How does this interact with WP user accounts? Permissions model for org-scoped portal?
+- **Roadmap fit:** v5.x.
+
+### 8. Saved replies with variables (richer canned responses)
+- **Problem:** Current canned responses are flat strings. Need `{client_name}`, `{ticket_id}`, `{assigned_tech}` variable substitution like email templates already have.
+- **Sketch:** Reuse the email template `{var}` and `{if var}…{endif var}` parser for canned responses.
+- **Signals:** Small lift, large daily impact for techs.
+- **Open questions:** None significant — pattern is proven in email templates.
+- **Roadmap fit:** v3.7 candidate (non-breaking) **or** v4.0 quick-reply drawer work.
+
+### 9. Public status page integration
+- **Problem:** When something is broken, every affected user opens a ticket. No mechanism to deflect with "we know, we're working on it."
+- **Sketch:** Banner on the submission form when an admin sets a "current incident" message. Optional StatusPage / Instatus webhook receiver.
+- **Signals:** Niche but high-impact during incidents.
+- **Open questions:** Build vs integrate. Most users probably don't run a separate status page.
+- **Roadmap fit:** v5.x or community plugin.
+
+### 10. SSO / SAML for technicians
+- **Problem:** Larger orgs running on SSO want techs to log in via Okta / Azure AD / Google Workspace, not WP-local accounts.
+- **Signals:** Solved by existing SSO plugins for WordPress generally — probably out of scope for us.
+- **Roadmap fit:** Likely **park** — recommend miniOrange / WP SAML SSO instead.
+
+---
+
+## Format for new entries
+
+```markdown
+### N. <short title>
+- **Problem:** What's the user pain? Be concrete.
+- **Sketch:** Rough shape — not a design, just enough to discuss.
+- **Signals:** Where's the demand from? How often heard? Anchors in real evidence.
+- **Open questions:** What we'd need to figure out before committing.
+- **Roadmap fit:** Best-guess milestone, or "park" / "out of scope."
+```
+
+Skip any field if there's nothing real to say — don't fill it with filler.
+
+---
+
+## Graveyard (rejected ideas)
+
+When something gets rejected outright (vs parked), drop a one-liner here so we don't relitigate it.
+
+- *(empty)*

--- a/docs/internal/new_features_discussion.md
+++ b/docs/internal/new_features_discussion.md
@@ -11,13 +11,15 @@ Last updated: 2026-05-04
 1. **Add anything** — half-formed ideas welcome. Worse to lose them than to keep a messy list.
 2. **Each entry has the same skeleton** — problem, sketch, signals, open questions, fit. Skeleton = forces the idea into honest shape.
 3. **Once an idea is shaped enough** — open a GitHub issue, attach to a milestone, remove from this doc.
-4. **Once an idea is rejected** — move to `parked_features.md` with the reasoning.
+4. **Once an idea is parked** (might come back later) — move to `parked_features.md` with the reasoning.
+5. **Once an idea is rejected outright** (won't come back) — drop a one-liner in the Graveyard section at the bottom of this file.
 
 ---
 
 ## Active discussion
 
 ### 1. AI-assisted reply suggestions
+
 - **Problem:** Technicians retype the same answer often. Canned responses help but require manual creation/maintenance.
 - **Sketch:** Per-ticket "Suggest reply" button → calls a configurable LLM endpoint (BYO API key — OpenAI / Anthropic / local Ollama) with redacted ticket context. Returns a draft, never auto-sends. Could optionally suggest categories + priority.
 - **Signals:** Industry baseline now (Zendesk AI, Intercom Fin, HubSpot ChatSpot). Self-hosted users want privacy → BYO key + local-LLM support is the differentiator vs SaaS.
@@ -25,6 +27,7 @@ Last updated: 2026-05-04
 - **Roadmap fit:** v4.4+ (after REST + webhooks land — sits naturally on top of the API surface).
 
 ### 2. Macros / automation rules
+
 - **Problem:** Today only assignment rules and SLA cron run automatically. Common asks: "after 24h with no client reply → close", "if priority=urgent and unassigned → notify lead", "if subject contains 'invoice' → tag billing + assign Cathy."
 - **Sketch:** Rules engine with WHEN (event/condition) → THEN (action) blocks. Reuses v4.1 event hooks. Admin UI is the hard part.
 - **Signals:** Top-3 ask in any helpdesk forum thread. Assignment rules already prove the pattern works.
@@ -32,6 +35,7 @@ Last updated: 2026-05-04
 - **Roadmap fit:** v4.4 or v5.0 — depends on v4.1 event hooks being live.
 
 ### 3. Tags (separate from categories)
+
 - **Problem:** Categories are hierarchical, slow to apply, and one-per-ticket in practice. Real-world triage wants quick, freeform, multi-value tagging ("vip", "needs-screenshot", "billing-related").
 - **Sketch:** New non-hierarchical taxonomy (`helpdesk_tag`). Inline tag input on the ticket editor. Filter chips on the inbox.
 - **Signals:** Categories taxonomy added in v3.0 already feels like the wrong shape for triage workflows.
@@ -39,6 +43,7 @@ Last updated: 2026-05-04
 - **Roadmap fit:** Pairs with v4.0 inbox redesign. Could land as v4.0 or v4.1.
 
 ### 4. Knowledge base / FAQ shortcode
+
 - **Problem:** Same questions get asked repeatedly. No first-line deflection mechanism.
 - **Sketch:** New CPT `helpdesk_kb`. `[helpdesk_kb]` shortcode. On the submission form, real-time search ("did you mean: …") before the user submits. Optionally feeds AI suggestions (#1).
 - **Signals:** Strong correlation between "good helpdesk" and "good KB" — companies that get this right have 30–50% deflection.
@@ -46,6 +51,7 @@ Last updated: 2026-05-04
 - **Roadmap fit:** v5.x — too big for any current milestone.
 
 ### 5. CSAT trend reporting
+
 - **Problem:** v3.0 added CSAT capture (`_ticket_csat`). No reporting on it. Captured data, never shown.
 - **Sketch:** New report card on Reports page — average CSAT, trend over time, breakdown by assignee. Sits next to existing reports.
 - **Signals:** Cheap win — data already exists, just needs a chart. Likely a v3.7.0 candidate if v3.x continues.
@@ -53,6 +59,7 @@ Last updated: 2026-05-04
 - **Roadmap fit:** v3.7 (small, non-breaking) **or** roll into v4.0 reports redesign ([#359](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/359)).
 
 ### 6. Time tracking on tickets
+
 - **Problem:** Agencies and MSPs running this as a billable-hours tool ask for time tracking constantly.
 - **Sketch:** Start/stop timer per ticket. Manual entry. Total time meta. Export to CSV. Optional integration with billing plugins (WooCommerce, FreshBooks).
 - **Signals:** Heard 3× from agency users. Real demand exists, but it's a feature segment, not the core use case.
@@ -60,6 +67,7 @@ Last updated: 2026-05-04
 - **Roadmap fit:** v5.x or never. Could also be a separate companion plugin.
 
 ### 7. Customer organizations / firms
+
 - **Problem:** Users at the same company are tracked as individuals. No way to see "all tickets from Acme Corp" or set per-company SLAs.
 - **Sketch:** New CPT `helpdesk_org`. Tickets link to org via meta. Per-org SLA override. Org-scoped portal view ("see all tickets from your team").
 - **Signals:** B2B helpdesk pattern. Adds significant data model complexity.
@@ -67,6 +75,7 @@ Last updated: 2026-05-04
 - **Roadmap fit:** v5.x.
 
 ### 8. Saved replies with variables (richer canned responses)
+
 - **Problem:** Current canned responses are flat strings. Need `{client_name}`, `{ticket_id}`, `{assigned_tech}` variable substitution like email templates already have.
 - **Sketch:** Reuse the email template `{var}` and `{if var}…{endif var}` parser for canned responses.
 - **Signals:** Small lift, large daily impact for techs.
@@ -74,6 +83,7 @@ Last updated: 2026-05-04
 - **Roadmap fit:** v3.7 candidate (non-breaking) **or** v4.0 quick-reply drawer work.
 
 ### 9. Public status page integration
+
 - **Problem:** When something is broken, every affected user opens a ticket. No mechanism to deflect with "we know, we're working on it."
 - **Sketch:** Banner on the submission form when an admin sets a "current incident" message. Optional StatusPage / Instatus webhook receiver.
 - **Signals:** Niche but high-impact during incidents.
@@ -81,6 +91,7 @@ Last updated: 2026-05-04
 - **Roadmap fit:** v5.x or community plugin.
 
 ### 10. SSO / SAML for technicians
+
 - **Problem:** Larger orgs running on SSO want techs to log in via Okta / Azure AD / Google Workspace, not WP-local accounts.
 - **Signals:** Solved by existing SSO plugins for WordPress generally — probably out of scope for us.
 - **Roadmap fit:** Likely **park** — recommend miniOrange / WP SAML SSO instead.
@@ -91,6 +102,7 @@ Last updated: 2026-05-04
 
 ```markdown
 ### N. <short title>
+
 - **Problem:** What's the user pain? Be concrete.
 - **Sketch:** Rough shape — not a design, just enough to discuss.
 - **Signals:** Where's the demand from? How often heard? Anchors in real evidence.
@@ -104,6 +116,6 @@ Skip any field if there's nothing real to say — don't fill it with filler.
 
 ## Graveyard (rejected ideas)
 
-When something gets rejected outright (vs parked), drop a one-liner here so we don't relitigate it.
+For ideas rejected outright (won't come back). One line each, just enough that future-us doesn't relitigate. **Parked** ideas (might come back) live in `parked_features.md` instead.
 
 - *(empty)*

--- a/docs/internal/parked_features.md
+++ b/docs/internal/parked_features.md
@@ -1,0 +1,61 @@
+# Parked Features (living document)
+
+Features that were on a roadmap (or seriously considered) and have been intentionally deprioritized. Not cancelled — parked. Each entry says **why it's parked** and **what would have to change** to bring it back.
+
+Last updated: 2026-05-04
+
+---
+
+## Zapier app
+
+**Originally:** v4.3.0 — issue [#382](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/382) (closed 2026-05-04, "not planned").
+**Parked:** 2026-05-04.
+
+### Why parked
+- Maintainer (Sean) doesn't use Zapier and has no internal pull for it.
+- Separate repo + Zapier platform compliance is a meaningful maintenance surface (auth flows, schema drift, listing reviews).
+- The v4.1 REST API + v4.2 signed webhooks cover the same automation use cases for users on Zapier, Make, n8n, IFTTT, or anything custom.
+- A community-built Zapier wrapper can sit on top of the public API later without us owning it.
+
+### What would bring it back
+- Real, repeated user requests (not "would be nice" — actual people asking).
+- A community contributor willing to own the Zapier-side code.
+- Direct revenue tie (e.g. paid tier where Zapier listing is a meaningful acquisition channel).
+
+### Successor / alternative
+v4.1 REST API ([#362](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/362)–[#370](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/370)) + v4.2 webhooks ([#371](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/371)–[#378](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/378)).
+
+---
+
+## Candidates to consider parking
+
+These are still on the roadmap but worth a deliberate keep/park decision before they land. Not parked yet — listed here so the question is in front of us.
+
+### Indigo design refresh ([#355](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/355))
+- v4.0 already ships a major UX shift (inbox-style admin, command palette, portal v2). Stacking a brand refresh on top risks change fatigue.
+- **Option A:** keep, ship as opt-in (current plan).
+- **Option B:** park until v4.1+ once the inbox layout has settled.
+- **Option C:** park indefinitely — let users keep current visual identity.
+
+### Microsoft Teams integration ([#380](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/380))
+- Adaptive Cards format is heavier than Slack/Discord webhooks.
+- Smaller user overlap (WP + Teams shop) than Slack.
+- **Option A:** keep — completionist (cover the big three).
+- **Option B:** park — ship Slack + Discord first, add Teams if requested.
+
+### Discord webhook ([#381](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/381))
+- Same question as Teams from a different angle. Discord users are a niche segment for a WordPress helpdesk.
+- **Option A:** keep — easy lift on top of the v4.2 webhook layer.
+- **Option B:** park — community can build it via the public webhook API.
+
+---
+
+## Format
+
+Each parked entry should answer:
+1. **What it was** — milestone + issue link + date parked.
+2. **Why parked** — concrete reasons, not "we'll get to it."
+3. **What would bring it back** — the trigger conditions for un-parking.
+4. **Successor / alternative** — what users do instead.
+
+Don't park things silently. If something gets dropped from a milestone, it lands here with reasoning, even if the answer is "no real demand yet."

--- a/docs/internal/parked_features.md
+++ b/docs/internal/parked_features.md
@@ -12,17 +12,20 @@ Last updated: 2026-05-04
 **Parked:** 2026-05-04.
 
 ### Why parked
+
 - Maintainer (Sean) doesn't use Zapier and has no internal pull for it.
 - Separate repo + Zapier platform compliance is a meaningful maintenance surface (auth flows, schema drift, listing reviews).
 - The v4.1 REST API + v4.2 signed webhooks cover the same automation use cases for users on Zapier, Make, n8n, IFTTT, or anything custom.
 - A community-built Zapier wrapper can sit on top of the public API later without us owning it.
 
 ### What would bring it back
+
 - Real, repeated user requests (not "would be nice" — actual people asking).
 - A community contributor willing to own the Zapier-side code.
 - Direct revenue tie (e.g. paid tier where Zapier listing is a meaningful acquisition channel).
 
 ### Successor / alternative
+
 v4.1 REST API ([#362](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/362)–[#370](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/370)) + v4.2 webhooks ([#371](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/371)–[#378](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/378)).
 
 ---
@@ -32,18 +35,21 @@ v4.1 REST API ([#362](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/
 These are still on the roadmap but worth a deliberate keep/park decision before they land. Not parked yet — listed here so the question is in front of us.
 
 ### Indigo design refresh ([#355](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/355))
+
 - v4.0 already ships a major UX shift (inbox-style admin, command palette, portal v2). Stacking a brand refresh on top risks change fatigue.
 - **Option A:** keep, ship as opt-in (current plan).
 - **Option B:** park until v4.1+ once the inbox layout has settled.
 - **Option C:** park indefinitely — let users keep current visual identity.
 
 ### Microsoft Teams integration ([#380](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/380))
+
 - Adaptive Cards format is heavier than Slack/Discord webhooks.
 - Smaller user overlap (WP + Teams shop) than Slack.
 - **Option A:** keep — completionist (cover the big three).
 - **Option B:** park — ship Slack + Discord first, add Teams if requested.
 
 ### Discord webhook ([#381](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/381))
+
 - Same question as Teams from a different angle. Discord users are a niche segment for a WordPress helpdesk.
 - **Option A:** keep — easy lift on top of the v4.2 webhook layer.
 - **Option B:** park — community can build it via the public webhook API.

--- a/docs/internal/release_v3.x.x_roadmap.md
+++ b/docs/internal/release_v3.x.x_roadmap.md
@@ -22,10 +22,12 @@ Status: **Active**
 Theme: Finish what v3.4 started on dark mode, plus the WCAG AA gaps surfaced during the v3.5 audit. Pure UX/a11y polish — no architectural changes.
 
 ### Dark mode
+
 - [ ] [#339](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/339) — Admin dark mode (respect WP `admin_color` schemes — midnight/modern)
 - [ ] [#340](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/340) — Email HTML `color-scheme: light dark` metadata + media query
 
 ### Accessibility (WCAG 2.2 AA)
+
 - [ ] [#341](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/341) — Skip-to-content link on Reports + Settings
 - [ ] [#342](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/342) — CSAT widget focus management after submit
 - [ ] [#343](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/343) — Heading hierarchy audit across portal + admin
@@ -44,15 +46,18 @@ Status: **Planned (after v3.6 ships)**
 Theme: Non-breaking groundwork that de-risks v4.0 / v4.1. **Why this exists:** v3.6 is pure cosmetic polish. v4.0 ships breaking changes (PHP/WP bumps, settings schema split, new admin paradigm) on top of a codebase that doesn't yet have the primitives those features assume. v3.7 lands the primitives so v4.0 issues build on a stable foundation, and gives anyone integrating with the plugin a runway to adopt new APIs before v4.0 lands.
 
 ### Hooks (the load-bearing one)
+
 - [ ] [#361](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/361) — Lifecycle action hooks (reply, status, assign, close, reopen, SLA, CSAT) — **moved from v4.1**
 
 ### Architecture decisions
+
 - [ ] [#390](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/390) — JS architecture spike — pick build/state pattern before v4.0 admin UI work starts
 - [ ] [#391](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/391) — Introduce `swh_get_option()` helper as read-through wrapper (de-risks v4.0 schema split)
 - [ ] [#393](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/393) — Deprecation helper — wrap `apply_filters_deprecated()` and `do_action_deprecated()`
 - [ ] [#394](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/394) — PSR-4 autoload for plugin classes
 
 ### Documentation + measurement
+
 - [ ] [#392](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/392) — Component inventory — document existing primitives before v4.0 sprawl
 - [ ] [#395](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/395) — Performance baseline — capture timings before v4.0 inbox redesign
 
@@ -69,6 +74,7 @@ Theme: Non-breaking groundwork that de-risks v4.0 / v4.1. **Why this exists:** v
 | Perf baseline | v4.0 inbox claims "500+ without lag" | Need numbers to regress against |
 
 ### Notes
+
 - All v3.7 work is non-breaking — same PHP/WP minimums.
 - v3.7 unblocks (or de-risks) every milestone in the v4.x lane. See `release_v4.x.x_roadmap.md`.
 

--- a/docs/internal/release_v3.x.x_roadmap.md
+++ b/docs/internal/release_v3.x.x_roadmap.md
@@ -1,0 +1,59 @@
+# v3.x Roadmap (living document)
+
+Polish, accessibility, and consistency lane. No breaking changes — all of v3.x stays on PHP 7.4 / WP 5.3 minimums. Breaking work is reserved for v4.0.
+
+Last updated: 2026-05-04
+
+---
+
+## v3.5.0 — Consistency & Feedback ✅ SHIPPED 2026-04-23
+
+Milestone: [#16](https://github.com/seanmousseau/seanmousseau/Simple-WP-Helpdesk/milestone/16) — 10/10 closed
+PR: [#387](https://github.com/seanmousseau/Simple-WP-Helpdesk/pull/387)
+
+Design tokens, badges, skeleton loaders, toast notifications, accessibility primitives, expanded E2E coverage. WCAG contrast fixes (2.16:1 → 4.5:1).
+
+---
+
+## v3.6.0 — Dark Mode Expansion & A11y Round 2
+
+Milestone: [#17](https://github.com/seanmousseau/Simple-WP-Helpdesk/milestone/17) — 0/10 closed
+Status: **Next up**
+Theme: Finish what v3.4 started on dark mode, plus the WCAG AA gaps surfaced during the v3.5 audit.
+
+### Dark mode
+- [ ] [#339](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/339) — Admin dark mode (respect WP `admin_color` schemes — midnight/modern)
+- [ ] [#340](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/340) — Email HTML `color-scheme: light dark` metadata + media query
+
+### Accessibility (WCAG 2.2 AA)
+- [ ] [#341](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/341) — Skip-to-content link on Reports + Settings
+- [ ] [#342](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/342) — CSAT widget focus management after submit
+- [ ] [#343](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/343) — Heading hierarchy audit across portal + admin
+- [ ] [#344](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/344) — `aria-live` on SLA badge + KPI card updates
+- [ ] [#345](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/345) — `:focus-visible` for mouse vs keyboard focus rings
+- [ ] [#346](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/346) — Portal token-expiry focus moves to lookup form
+- [ ] [#347](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/347) — Touch-target audit (≥44×44 WCAG AA)
+- [ ] [#348](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/348) — Contrast audit of internal-note tokens
+
+### Notes
+- All v3.6 work is non-breaking — same PHP/WP minimums.
+- Dark mode admin pairs with the badge hex purge from v3.5 (already done) — inline hex values won't theme correctly.
+- Acceptance criteria for every issue includes a Playwright section.
+
+---
+
+## Beyond v3.6
+
+No additional v3.x minor releases planned. The next release after v3.6 is **v4.0.0**, which raises PHP/WP minimums and is allowed to ship breaking changes. Anything that surfaces as a v3.x candidate after v3.6 should be evaluated against:
+
+1. Can it ship without breaking changes? → New v3.7.0 issue.
+2. Does it require PHP 8.0 / WP 6.0 / schema migration? → v4.x roadmap.
+3. Is it speculative / not yet validated? → `new_features_discussion.md`.
+
+---
+
+## How this doc stays current
+
+- Update the milestone link table when a release ships (mark ✅ SHIPPED + date + PR).
+- Issue status reflects GitHub — not duplicated here. This doc is a navigation index, not a source of truth for state.
+- When v3.6 closes, archive its section under a "Shipped" header at the bottom and bring the next planning section up top.

--- a/docs/internal/release_v3.x.x_roadmap.md
+++ b/docs/internal/release_v3.x.x_roadmap.md
@@ -1,6 +1,6 @@
 # v3.x Roadmap (living document)
 
-Polish, accessibility, and consistency lane. No breaking changes — all of v3.x stays on PHP 7.4 / WP 5.3 minimums. Breaking work is reserved for v4.0.
+Polish, accessibility, and v4 foundation lane. No breaking changes — all of v3.x stays on PHP 7.4 / WP 5.3 minimums. Breaking work is reserved for v4.0.
 
 Last updated: 2026-05-04
 
@@ -8,7 +8,7 @@ Last updated: 2026-05-04
 
 ## v3.5.0 — Consistency & Feedback ✅ SHIPPED 2026-04-23
 
-Milestone: [#16](https://github.com/seanmousseau/seanmousseau/Simple-WP-Helpdesk/milestone/16) — 10/10 closed
+Milestone: [#16](https://github.com/seanmousseau/Simple-WP-Helpdesk/milestone/16) — 10/10 closed
 PR: [#387](https://github.com/seanmousseau/Simple-WP-Helpdesk/pull/387)
 
 Design tokens, badges, skeleton loaders, toast notifications, accessibility primitives, expanded E2E coverage. WCAG contrast fixes (2.16:1 → 4.5:1).
@@ -18,8 +18,8 @@ Design tokens, badges, skeleton loaders, toast notifications, accessibility prim
 ## v3.6.0 — Dark Mode Expansion & A11y Round 2
 
 Milestone: [#17](https://github.com/seanmousseau/Simple-WP-Helpdesk/milestone/17) — 0/10 closed
-Status: **Next up**
-Theme: Finish what v3.4 started on dark mode, plus the WCAG AA gaps surfaced during the v3.5 audit.
+Status: **Active**
+Theme: Finish what v3.4 started on dark mode, plus the WCAG AA gaps surfaced during the v3.5 audit. Pure UX/a11y polish — no architectural changes.
 
 ### Dark mode
 - [ ] [#339](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/339) — Admin dark mode (respect WP `admin_color` schemes — midnight/modern)
@@ -35,25 +35,59 @@ Theme: Finish what v3.4 started on dark mode, plus the WCAG AA gaps surfaced dur
 - [ ] [#347](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/347) — Touch-target audit (≥44×44 WCAG AA)
 - [ ] [#348](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/348) — Contrast audit of internal-note tokens
 
+---
+
+## v3.7.0 — v4 Foundations
+
+Milestone: [#22](https://github.com/seanmousseau/Simple-WP-Helpdesk/milestone/22) — 0/7 closed
+Status: **Planned (after v3.6 ships)**
+Theme: Non-breaking groundwork that de-risks v4.0 / v4.1. **Why this exists:** v3.6 is pure cosmetic polish. v4.0 ships breaking changes (PHP/WP bumps, settings schema split, new admin paradigm) on top of a codebase that doesn't yet have the primitives those features assume. v3.7 lands the primitives so v4.0 issues build on a stable foundation, and gives anyone integrating with the plugin a runway to adopt new APIs before v4.0 lands.
+
+### Hooks (the load-bearing one)
+- [ ] [#361](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/361) — Lifecycle action hooks (reply, status, assign, close, reopen, SLA, CSAT) — **moved from v4.1**
+
+### Architecture decisions
+- [ ] [#390](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/390) — JS architecture spike — pick build/state pattern before v4.0 admin UI work starts
+- [ ] [#391](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/391) — Introduce `swh_get_option()` helper as read-through wrapper (de-risks v4.0 schema split)
+- [ ] [#393](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/393) — Deprecation helper — wrap `apply_filters_deprecated()` and `do_action_deprecated()`
+- [ ] [#394](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/394) — PSR-4 autoload for plugin classes
+
+### Documentation + measurement
+- [ ] [#392](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/392) — Component inventory — document existing primitives before v4.0 sprawl
+- [ ] [#395](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/395) — Performance baseline — capture timings before v4.0 inbox redesign
+
+### Why these specifically
+
+| Item | What v4.x needs it for | Why now (v3.7) vs later |
+|------|----------------------|-----|
+| Lifecycle hooks | All of v4.1 + v4.2 builds on them | Hooks are a one-way door once public — ship clean and let them settle a release before REST + webhooks consume them |
+| JS architecture | v4.0 inbox, command palette, saved views, drawer | Without a decision, each v4.0 issue reinvents the wheel |
+| `swh_get_option()` | v4.0 schema split ([#356](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/356)) | Land the signature now (still backed by monolithic option) so v4.0 only changes the implementation |
+| Component inventory | Every v4.0 UI issue | Prevents ad-hoc primitives + indigo-refresh fights |
+| Deprecation helper | v4.0 hook deprecations ([#360](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/360)) | Makes the deprecations mechanical |
+| PSR-4 autoload | v4.0/v4.1 will add ~10 new classes | Cleaner bootstrap, contributors don't fight `require_once` |
+| Perf baseline | v4.0 inbox claims "500+ without lag" | Need numbers to regress against |
+
 ### Notes
-- All v3.6 work is non-breaking — same PHP/WP minimums.
-- Dark mode admin pairs with the badge hex purge from v3.5 (already done) — inline hex values won't theme correctly.
-- Acceptance criteria for every issue includes a Playwright section.
+- All v3.7 work is non-breaking — same PHP/WP minimums.
+- v3.7 unblocks (or de-risks) every milestone in the v4.x lane. See `release_v4.x.x_roadmap.md`.
 
 ---
 
-## Beyond v3.6
+## Beyond v3.7
 
-No additional v3.x minor releases planned. The next release after v3.6 is **v4.0.0**, which raises PHP/WP minimums and is allowed to ship breaking changes. Anything that surfaces as a v3.x candidate after v3.6 should be evaluated against:
+The next release after v3.7 is **v4.0.0**, which raises PHP/WP minimums and is allowed to ship breaking changes. Anything surfacing as a v3.x candidate after v3.7 should be evaluated against:
 
-1. Can it ship without breaking changes? → New v3.7.0 issue.
+1. Can it ship without breaking changes? → New v3.8.0 issue.
 2. Does it require PHP 8.0 / WP 6.0 / schema migration? → v4.x roadmap.
 3. Is it speculative / not yet validated? → `new_features_discussion.md`.
+
+Cheap v3.x candidates already identified in `new_features_discussion.md`: **CSAT trend reporting** (data exists, just needs a chart) and **richer canned responses with variable substitution** (reuses the email template parser).
 
 ---
 
 ## How this doc stays current
 
-- Update the milestone link table when a release ships (mark ✅ SHIPPED + date + PR).
+- Update the milestone tables when a release ships (mark ✅ SHIPPED + date + PR).
 - Issue status reflects GitHub — not duplicated here. This doc is a navigation index, not a source of truth for state.
-- When v3.6 closes, archive its section under a "Shipped" header at the bottom and bring the next planning section up top.
+- When a release closes, archive its section under a "Shipped" header at the bottom and bring the next planning section up top.

--- a/docs/internal/release_v4.x.x_roadmap.md
+++ b/docs/internal/release_v4.x.x_roadmap.md
@@ -22,12 +22,14 @@ Milestone: [#18](https://github.com/seanmousseau/Simple-WP-Helpdesk/milestone/18
 Theme: Inbox-style triage, command palette, portal v2, modernization. Breaking changes allowed.
 
 ### Foundation
+
 - [ ] [#356](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/356) — Settings schema migration (`swh_options` → topic sub-options) — **enables v4.1 API key storage**
 - [ ] [#357](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/357) — Bump PHP minimum to 8.0
 - [ ] [#358](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/358) — Bump WordPress minimum to 6.0
 - [ ] [#360](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/360) — Deprecate pre-3.0 filter hooks
 
 ### Admin UX rewrite
+
 - [ ] [#349](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/349) — Inbox-style Tickets admin page
 - [ ] [#350](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/350) — Quick-reply drawer from inbox preview
 - [ ] [#351](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/351) — Command palette (Ctrl/Cmd+K)
@@ -35,11 +37,13 @@ Theme: Inbox-style triage, command palette, portal v2, modernization. Breaking c
 - [ ] [#353](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/353) — Sticky bulk-action bar on selection
 
 ### Frontend + reporting
+
 - [ ] [#354](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/354) — Portal v2 — conversation-first layout
 - [ ] [#355](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/355) — Indigo design refresh (opt-in) + typography upgrade — **see parked_features.md, decision pending**
 - [ ] [#359](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/359) — Reports redesign — drill-down + period-over-period
 
 ### Migration cost
+
 - v3.5 → v4.0 upgrade routine handles `swh_options` split-out.
 - Hosts on PHP 7.4 / WP 5.3–5.9 stay on the v3.6 LTS branch.
 
@@ -67,8 +71,8 @@ Theme: Public REST API v1, scoped API keys, OpenAPI spec, per-key rate limiting.
 ## v4.2.0 — Outbound Webhooks & Signing
 
 Milestone: [#20](https://github.com/seanmousseau/Simple-WP-Helpdesk/milestone/20) — 0/8 closed
-Theme: HMAC-SHA256 signed outbound webhooks consuming v4.1 event hooks.
-**Depends on:** v4.1 lifecycle action hooks ([#361](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/361)).
+Theme: HMAC-SHA256 signed outbound webhooks consuming the v3.7 lifecycle action hooks via v4.1's REST surface.
+**Depends on:** v3.7 lifecycle action hooks ([#361](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/361)) + v4.1 REST API ([#362](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/362)).
 
 - [ ] [#371](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/371) — Subscription UI (per-event checkboxes, secret, target URL)
 - [ ] [#372](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/372) — HMAC-SHA256 payload signing (`X-SWH-Signature`, timestamp, delivery ID)

--- a/docs/internal/release_v4.x.x_roadmap.md
+++ b/docs/internal/release_v4.x.x_roadmap.md
@@ -10,7 +10,9 @@ Last updated: 2026-05-04
 
 > Workflow-first admin → eventing → webhooks → native integrations.
 
-Each release builds on the last. The order is load-bearing: **v4.1 needs the v4.0 settings migration, v4.2 needs the v4.1 event surface, v4.3 needs v4.2 signed webhooks.** Don't reorder.
+Each release builds on the last. The order is load-bearing: **v4.1 needs the v3.7 hooks + v4.0 settings migration, v4.2 needs the v4.1 REST surface, v4.3 needs v4.2 signed webhooks.** Don't reorder.
+
+> ⚠️ **Foundation in v3.7.** Several primitives that v4.x depends on land in v3.7.0 ("v4 Foundations") rather than v4.0 — lifecycle action hooks, `swh_get_option()` helper, deprecation helper, JS architecture, PSR-4 autoload, component inventory, perf baseline. See `release_v3.x.x_roadmap.md` for the full list. v4.x assumes those primitives are in place.
 
 ---
 
@@ -45,11 +47,11 @@ Theme: Inbox-style triage, command palette, portal v2, modernization. Breaking c
 
 ## v4.1.0 — Event Surface & REST API
 
-Milestone: [#19](https://github.com/seanmousseau/Simple-WP-Helpdesk/milestone/19) — 0/10 closed
-Theme: Foundation for integrations. Action hooks, public REST API v1, scoped API keys, OpenAPI spec, per-key rate limiting.
-**Depends on:** v4.0 settings schema migration ([#356](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/356)).
+Milestone: [#19](https://github.com/seanmousseau/Simple-WP-Helpdesk/milestone/19) — 0/9 closed (was 10; lifecycle hooks moved to v3.7)
+Theme: Public REST API v1, scoped API keys, OpenAPI spec, per-key rate limiting. Sits on top of v3.7 lifecycle hooks ([#361](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/361)) and v4.0 settings split ([#356](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/356)).
+**Depends on:** v3.7 lifecycle action hooks ([#361](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/361)) + v4.0 settings schema migration ([#356](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/356)).
 
-- [ ] [#361](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/361) — Lifecycle action hooks (reply, status, assign, close, reopen, SLA, CSAT)
+- ~~[#361](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/361) — Lifecycle action hooks~~ → **moved to v3.7** (de-risks v4.1 by giving hooks a release cycle to settle)
 - [ ] [#362](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/362) — REST API v1: tickets CRUD (`swh/v1/tickets`)
 - [ ] [#363](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/363) — REST API v1: replies (`swh/v1/tickets/{id}/replies`)
 - [ ] [#364](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/364) — REST API v1: read-only endpoints (technicians, categories, settings)

--- a/docs/internal/release_v4.x.x_roadmap.md
+++ b/docs/internal/release_v4.x.x_roadmap.md
@@ -1,0 +1,111 @@
+# v4.x Roadmap (living document)
+
+Major lane. **Breaking changes allowed.** Raises minimums (PHP 8.0, WP 6.0), introduces a new admin paradigm, and lays the integration foundation for everything downstream.
+
+Last updated: 2026-05-04
+
+---
+
+## Lane theme
+
+> Workflow-first admin → eventing → webhooks → native integrations.
+
+Each release builds on the last. The order is load-bearing: **v4.1 needs the v4.0 settings migration, v4.2 needs the v4.1 event surface, v4.3 needs v4.2 signed webhooks.** Don't reorder.
+
+---
+
+## v4.0.0 — Workflow-First Admin
+
+Milestone: [#18](https://github.com/seanmousseau/Simple-WP-Helpdesk/milestone/18) — 0/12 closed
+Theme: Inbox-style triage, command palette, portal v2, modernization. Breaking changes allowed.
+
+### Foundation
+- [ ] [#356](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/356) — Settings schema migration (`swh_options` → topic sub-options) — **enables v4.1 API key storage**
+- [ ] [#357](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/357) — Bump PHP minimum to 8.0
+- [ ] [#358](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/358) — Bump WordPress minimum to 6.0
+- [ ] [#360](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/360) — Deprecate pre-3.0 filter hooks
+
+### Admin UX rewrite
+- [ ] [#349](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/349) — Inbox-style Tickets admin page
+- [ ] [#350](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/350) — Quick-reply drawer from inbox preview
+- [ ] [#351](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/351) — Command palette (Ctrl/Cmd+K)
+- [ ] [#352](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/352) — Saved views (per-user filter persistence)
+- [ ] [#353](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/353) — Sticky bulk-action bar on selection
+
+### Frontend + reporting
+- [ ] [#354](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/354) — Portal v2 — conversation-first layout
+- [ ] [#355](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/355) — Indigo design refresh (opt-in) + typography upgrade — **see parked_features.md, decision pending**
+- [ ] [#359](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/359) — Reports redesign — drill-down + period-over-period
+
+### Migration cost
+- v3.5 → v4.0 upgrade routine handles `swh_options` split-out.
+- Hosts on PHP 7.4 / WP 5.3–5.9 stay on the v3.6 LTS branch.
+
+---
+
+## v4.1.0 — Event Surface & REST API
+
+Milestone: [#19](https://github.com/seanmousseau/Simple-WP-Helpdesk/milestone/19) — 0/10 closed
+Theme: Foundation for integrations. Action hooks, public REST API v1, scoped API keys, OpenAPI spec, per-key rate limiting.
+**Depends on:** v4.0 settings schema migration ([#356](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/356)).
+
+- [ ] [#361](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/361) — Lifecycle action hooks (reply, status, assign, close, reopen, SLA, CSAT)
+- [ ] [#362](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/362) — REST API v1: tickets CRUD (`swh/v1/tickets`)
+- [ ] [#363](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/363) — REST API v1: replies (`swh/v1/tickets/{id}/replies`)
+- [ ] [#364](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/364) — REST API v1: read-only endpoints (technicians, categories, settings)
+- [ ] [#365](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/365) — API key management UI (scoped, per-key rate limit, revocable)
+- [ ] [#366](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/366) — Per-endpoint capability + permission_callback wiring
+- [ ] [#367](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/367) — Per-key rate limiting (60/min default)
+- [ ] [#368](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/368) — OpenAPI 3.1 spec + Redoc viewer (hidden admin page)
+- [ ] [#369](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/369) — Opt-in API access audit log (last 10 accesses per ticket)
+- [ ] [#370](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/370) — Playwright: 7 new sections for REST API
+
+---
+
+## v4.2.0 — Outbound Webhooks & Signing
+
+Milestone: [#20](https://github.com/seanmousseau/Simple-WP-Helpdesk/milestone/20) — 0/8 closed
+Theme: HMAC-SHA256 signed outbound webhooks consuming v4.1 event hooks.
+**Depends on:** v4.1 lifecycle action hooks ([#361](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/361)).
+
+- [ ] [#371](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/371) — Subscription UI (per-event checkboxes, secret, target URL)
+- [ ] [#372](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/372) — HMAC-SHA256 payload signing (`X-SWH-Signature`, timestamp, delivery ID)
+- [ ] [#373](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/373) — Delivery queue with exponential backoff (WP-Cron, 5 attempts)
+- [ ] [#374](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/374) — SSRF gate: block private IPs, https-only (except localhost), 10s timeout, 1MB cap
+- [ ] [#375](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/375) — Delivery log UI (last 100 per subscription, redeliver button)
+- [ ] [#376](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/376) — Per-subscription test event + ping endpoint validation
+- [ ] [#377](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/377) — Receiver verification docs (PHP, Node, Python examples)
+- [ ] [#378](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/378) — Playwright: 4 new sections (UI, signing, retry, SSRF)
+
+---
+
+## v4.3.0 — Core Integrations
+
+Milestone: [#21](https://github.com/seanmousseau/Simple-WP-Helpdesk/milestone/21) — 0/7 closed (Zapier issue [#382](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/382) **closed/parked** — see `parked_features.md`)
+Theme: Native integrations sitting on the v4.2 webhook layer + reply-by-email v2 + SMTP abstraction.
+**Depends on:** v4.2 signed webhooks ([#372](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/372)).
+
+- [ ] [#379](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/379) — Slack native (incoming webhook, pre-formatted blocks)
+- [ ] [#380](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/380) — Microsoft Teams (incoming webhook, Adaptive Cards)
+- [ ] [#381](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/381) — Discord (embed format)
+- ~~[#382](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/382) — Zapier app~~ → **PARKED** (`parked_features.md`)
+- [ ] [#383](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/383) — Reply-by-email v2: DKIM + In-Reply-To threading + multipart attachments
+- [ ] [#384](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/384) — SMTP abstraction (compatible with WP Mail SMTP / FluentSMTP)
+- [ ] [#385](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/385) — Integrations marketing page in admin (cards, setup deep-links)
+- [ ] [#386](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/386) — Playwright: 5 new sections (Slack, Teams, Discord, inbound v2, integrations page)
+
+---
+
+## Open decisions (need user input)
+
+1. **Indigo design refresh ([#355](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/355))** — opt-in or default? Land in v4.0 alongside the inbox redesign or hold for v4.1+? Risks UI churn fatigue if shipped together with the inbox rewrite.
+2. **v3.6 LTS branch** — explicit policy or informal? Decide before v4.0 ships so users on PHP 7.4 know what they're getting.
+3. **OpenAPI spec hosting ([#368](https://github.com/seanmousseau/Simple-WP-Helpdesk/issues/368))** — admin-hidden page (current plan) or also public docs site?
+
+---
+
+## How this doc stays current
+
+- Update milestone tables when issues open/close (just the count + state).
+- When a release ships, archive its full section under "Shipped" at the bottom and tighten the next-up section.
+- New v4.x ideas → propose in `new_features_discussion.md` first, promote to a milestone issue once shaped.


### PR DESCRIPTION
## Summary

- Adds `docs/internal/` as the home for living planning docs (roadmaps, parked features, new feature discussion).
- Closes the Zapier app (#382) as parked — REST + webhooks cover the same use cases.
- Establishes a new **v3.7.0 — v4 Foundations** milestone with 7 non-breaking primitives that de-risk v4.0/v4.1.

## What's in this PR

Four new docs under `docs/internal/`:

1. **`release_v3.x.x_roadmap.md`** — v3.5 shipped, v3.6 active (a11y + dark mode), v3.7 planned (v4 foundations).
2. **`release_v4.x.x_roadmap.md`** — v4.0 → v4.3 with explicit dependency chain. Banner up top flagging the v3.7 foundation dependency.
3. **`parked_features.md`** — Zapier as the first formal entry; flags Indigo refresh, Teams, Discord as candidates.
4. **`new_features_discussion.md`** — 10 ideas not yet on a roadmap (AI replies, macros, tags, CSAT trends, time tracking, etc.).

## Roadmap changes on GitHub (already applied, this PR documents them)

- Issue #382 (Zapier app) closed as not planned.
- Milestone **v3.7.0 — v4 Foundations** created.
- Issue #361 (lifecycle action hooks) moved from v4.1 → v3.7 to give the hook surface a release cycle to settle before REST + webhooks consume it.
- 6 new issues opened under v3.7: #390 (JS architecture), #391 (`swh_get_option()` helper), #392 (component inventory), #393 (deprecation helper), #394 (PSR-4 autoload), #395 (perf baseline).
- v4.1 milestone count adjusted (10 → 9) reflecting the #361 move.

## Why v3.7 exists

v3.6 is pure cosmetic polish — none of it prepares the codebase for v4.0's hard work (PHP/WP bumps, settings schema split, new admin paradigm, REST surface). v3.7 lands the primitives those features assume so v4.0 issues build on a stable foundation. All v3.7 work is non-breaking — same PHP 7.4 / WP 5.3 minimums.

## Test plan

- [x] Local gate passes (`make test-docker`: lint, PHPCS, PHPStan, PHPUnit 52/52, Semgrep)
- [ ] Docs render correctly on GitHub
- [ ] Cross-links between the four internal docs resolve
- [ ] Milestone + issue links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added living release roadmaps for v3.x and v4.x with milestones, statuses, constraints, and planned scopes.
  * Created a structured "New Features — Discussion" workflow with a reusable entry template and ten starter feature sketches to guide prioritization.
  * Introduced a parked-features registry (includes a Zapier app entry) with explicit park/unpark criteria and candidate lists.
  * Updated the changelog to reference these internal planning documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->