### PR TITLE
fix: null-guard $assignee_user before reading user_email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ starting from the next release after 1.8.
 - `docs/usage.md` expanded technician section (categories, SLA, merge, reporting, canned responses).
 - `docs/security.md` additions: token empty-value rejection, inbound webhook Bearer auth, MIME filter hook.
 
+### Fixed
+
+- **PHPStan null-guard on assignee email send (`admin/class-ticket-editor.php`):** `get_userdata()` returns `WP_User|false`, but the assignment-notification block read `$assignee_user->user_email` without a null-guard. Surfaced as a CI failure on PHP 8.1+ after the GitHub Actions composer cache evicted (cache miss → fresh install pulled an updated WP stubs version). Pre-existing code from v3.4; never reached in practice because callers always pass a valid user ID.
+
 ---
 
 ## [3.5.0] — 2026-04-23

--- a/simple-wp-helpdesk/admin/class-ticket-editor.php
+++ b/simple-wp-helpdesk/admin/class-ticket-editor.php
@@ -526,7 +526,7 @@ function swh_save_ticket_data( $post_id, $post, $update ) {
 		$assignee_user    = get_userdata( $assigned_to );
 		$assign_raw_name  = swh_get_string_meta( $post_id, '_ticket_name' );
 		$assign_ticket_id = swh_get_string_meta( $post_id, '_ticket_uid' );
-		if ( $assignee_user->user_email ) {
+		if ( $assignee_user && $assignee_user->user_email ) {
 			$assign_data = array(
 				'name'           => $assign_raw_name ? $assign_raw_name : 'Client',
 				'email'          => swh_get_string_meta( $post_id, '_ticket_email' ),


### PR DESCRIPTION
## Summary

- Adds a null-guard on `$assignee_user` before reading `->user_email` in `admin/class-ticket-editor.php`.
- Resolves the PHPStan `property.nonObject` failure flagged on PHP 8.1 / 8.2 / 8.3 in CI.

## Background

`get_userdata()` returns `WP_User|false`. The assignment-notification block on lines 525–544 read `$assignee_user->user_email` without checking for `false`. PHPStan 2.x correctly flags this on PHP 8.1+. PHP 7.4 is unaffected because PHPStan 2.x requires 8.1+ and is skipped on the 7.4 matrix entry.

The code is pre-existing from v3.4 (commit `ea2190f4`, Apr 9). v3.5.0 release CI passed Apr 23. Failure surfaced now because the GitHub Actions composer cache (keyed on `composer.lock`) evicted after >7 days unused, forcing a fresh `composer install` that pulled an updated WP stubs version with stricter `WP_User|false` typing.

In practice the null branch is never reached — `$assigned_to` always comes from a valid form-submitted user ID — but the null-guard makes the static-analysis contract explicit.

## Why no unit test

Adding one would require setting up `WP_Mock` for the entire `swh_save_ticket_data()` flow (~600 lines of WP dependencies). PHPStan itself is the regression guard: re-introducing `$user->prop` without a null-check on a `WP_User|false` will fail level 9 again.

## Test plan

- [x] `make test-docker` passes locally (lint, PHPCS, PHPStan, PHPUnit 52/52, Semgrep)
- [ ] CI green on PHP 7.4 / 8.1 / 8.2 / 8.3
- [ ] PR #396 (docs/internal-roadmap) rebases cleanly onto this fix and goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in the assignment notification email flow to prevent crashes when the assignee user account is missing or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->