### PR TITLE
docs(internal): establish docs/internal/ as single-source-of-truth doc set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -601,6 +601,9 @@ Theme: **Dark Mode Expansion & Accessibility Round 2.** Pure UX/a11y polish — 
 ---
 
 [Unreleased]: https://github.com/seanmousseau/Simple-WP-Helpdesk/compare/v3.5.0...HEAD
+[Unreleased]: https://github.com/seanmousseau/Simple-WP-Helpdesk/compare/v3.7.0...HEAD
+[3.7.0]: https://github.com/seanmousseau/Simple-WP-Helpdesk/compare/v3.6.0...v3.7.0
+[3.6.0]: https://github.com/seanmousseau/Simple-WP-Helpdesk/compare/v3.5.0...v3.6.0
 [3.5.0]: https://github.com/seanmousseau/Simple-WP-Helpdesk/compare/v3.4.1...v3.5.0
 [3.4.1]: https://github.com/seanmousseau/Simple-WP-Helpdesk/compare/v3.4.0...v3.4.1
 [3.4.0]: https://github.com/seanmousseau/Simple-WP-Helpdesk/compare/v3.3.0...v3.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ starting from the next release after 1.8.
 
 ---
 
+## [Unreleased]
+
+### Internal
+
+- Established `docs/internal/` as the single-source-of-truth doc set for developers and AI agents: README index, design-document (with 17 numbered load-bearing invariants), coding-guide, testing-guide, security-model, api-contract, data-dictionary, config-reference, design-guide. Every doc carries an Update protocol so the set stays current as part of normal PR flow.
+- Trimmed `CLAUDE.md` from 398 to 133 lines — now a routing index + hot-invariants list + dev environment reference. Sprawling sections (Common Pitfalls, full test taxonomy, security conventions, release process) replaced with pointers to the corresponding internal doc.
+
+---
+
 ## [3.7.0] — 2026-05-13
 
 Theme: **v4 Foundations.** Non-breaking groundwork that de-risks v4.0 / v4.1. No PHP/WP minimum bumps, no schema changes, no UX changes — primitives that v4.x features will build on, plus a runway for integrators to adopt new APIs before v4.0 lands. Closes milestone [#22](https://github.com/seanmousseau/Simple-WP-Helpdesk/milestone/22) (7/7).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -600,7 +600,6 @@ Theme: **Dark Mode Expansion & Accessibility Round 2.** Pure UX/a11y polish — 
 
 ---
 
-[Unreleased]: https://github.com/seanmousseau/Simple-WP-Helpdesk/compare/v3.5.0...HEAD
 [Unreleased]: https://github.com/seanmousseau/Simple-WP-Helpdesk/compare/v3.7.0...HEAD
 [3.7.0]: https://github.com/seanmousseau/Simple-WP-Helpdesk/compare/v3.6.0...v3.7.0
 [3.6.0]: https://github.com/seanmousseau/Simple-WP-Helpdesk/compare/v3.5.0...v3.6.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Before working on anything non-trivial, route via `docs/internal/README.md`. Com
 | UI/UX patterns, dark mode wiring | `docs/internal/design-guide.md` + `docs/internal/component-inventory.md` |
 | JS build, `@wordpress/scripts`, bundle budget | `docs/internal/js-architecture.md` |
 | Perf numbers + `make bench` | `docs/internal/performance-baseline.md` |
-| Release roadmaps | `docs/internal/release_v3.x.x_roadmap.md`, `release_v4.x.x_roadmap.md` |
+| Release roadmaps | `docs/internal/release_v3.x.x_roadmap.md`, `docs/internal/release_v4.x.x_roadmap.md` |
 | Operator / end-user docs | `docs/index.md` and the rest of `docs/*.md` (NOT `docs/internal/`) |
 
 ## Hot invariants (must hold in working memory)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,371 +1,106 @@
 # CLAUDE.md
 
+Working-memory for AI agents on Simple WP Helpdesk. Hot invariants, dev commands, and routing pointers — full project docs live in `docs/internal/`.
+
 ## Project Overview
 
 Simple WP Helpdesk — a WordPress helpdesk/ticketing plugin. No custom DB tables; uses CPT (`helpdesk_ticket`), comments, post meta, and `wp_options`.
 
-- **Version:** 3.6.0 | **WP:** 5.3+ | **PHP:** 7.4+ | **Repo:** seanmousseau/Simple-WP-Helpdesk
+- **Version:** 3.7.0 | **WP:** 5.3+ | **PHP:** 7.4+ | **Repo:** seanmousseau/Simple-WP-Helpdesk
+- **Plugin lives in:** `simple-wp-helpdesk/` subdir. Repo root holds dev tooling only.
 
-## Repository Structure
+## Where to read
 
-The repo root holds project tooling; the actual WordPress plugin lives inside `simple-wp-helpdesk/`.
+Before working on anything non-trivial, route via `docs/internal/README.md`. Common intents:
 
-```
-Simple-WP-Helpdesk/                     # repo root
-├── simple-wp-helpdesk/                 # the WP plugin directory (this is what gets zipped)
-│   ├── simple-wp-helpdesk.php          # Bootstrap: constants, requires, lifecycle hooks
-│   ├── readme.txt                      # WP.org readme (stable tag + changelog)
-│   ├── includes/
-│   │   ├── helpers.php                 # Defaults, statuses, anti-spam, rate limiting
-│   │   ├── class-installer.php         # Activation, deactivation, uninstall, upgrade, CPT
-│   │   ├── class-email.php             # Template parsing, email sending, HTML wrapping
-│   │   ├── class-ticket.php            # File proxy, uploads, deletion, comment filters
-│   │   └── class-cron.php              # Auto-close, retention (tickets + attachments)
-│   ├── admin/
-│   │   ├── class-settings.php          # Settings page render + save handler
-│   │   ├── class-ticket-editor.php     # Meta boxes, save_post, conversation UI
-│   │   ├── class-ticket-list.php       # Columns, sorting, filters, admin styles
-│   │   ├── class-reporting.php         # Reporting AJAX endpoints (status, resolution, trend, first-response)
-│   │   └── class-reporting-ui.php      # Reports submenu page render + Chart.js enqueue
-│   ├── frontend/
-│   │   ├── class-shortcode.php         # [submit_ticket] + [helpdesk_portal] shortcodes
-│   │   └── class-portal.php            # Client portal view
-│   ├── vendor/plugin-update-checker/   # GitHub auto-updater library (shipped with plugin)
-│   ├── assets/                         # CSS, JS
-│   └── languages/                      # .pot/.po/.mo
-├── docs/                               # internal + developer docs (not shipped)
-├── tests/                              # PHPUnit unit tests
-├── testing/                            # Playwright E2E + scripts
-├── docker/                             # docker-compose test stack
-├── composer.json / phpstan.neon        # dev tooling at repo root
-└── CHANGELOG.md                        # changelog (mirrored into readme.txt)
-```
+| Intent | Read |
+|---|---|
+| Architecture / "why is the code shaped this way?" | `docs/internal/design-document.md` |
+| Load-bearing invariants (BEFORE changing anything) | `docs/internal/design-document.md` — invariant table |
+| Conventions, naming, security hot list | `docs/internal/coding-guide.md` |
+| Testing — when to add what, commands, gotchas | `docs/internal/testing-guide.md` |
+| Threat model, capability matrix, attack surfaces | `docs/internal/security-model.md` |
+| Hooks, REST, AJAX, shortcodes — the public API | `docs/internal/api-contract.md` |
+| Post meta / comment meta / transients / options layout | `docs/internal/data-dictionary.md` |
+| Operator-tunable settings (the 7-group taxonomy) | `docs/internal/config-reference.md` |
+| UI/UX patterns, dark mode wiring | `docs/internal/design-guide.md` + `docs/internal/component-inventory.md` |
+| JS build, `@wordpress/scripts`, bundle budget | `docs/internal/js-architecture.md` |
+| Perf numbers + `make bench` | `docs/internal/performance-baseline.md` |
+| Release roadmaps | `docs/internal/release_v3.x.x_roadmap.md`, `release_v4.x.x_roadmap.md` |
+| Operator / end-user docs | `docs/index.md` and the rest of `docs/*.md` (NOT `docs/internal/`) |
 
-Constants: `SWH_PLUGIN_DIR`, `SWH_PLUGIN_URL`, `SWH_PLUGIN_FILE` — use these instead of `__FILE__` in module files.
+## Hot invariants (must hold in working memory)
 
-## Making Changes
+These are the ones that bite most often. The full numbered table is in `docs/internal/design-document.md`. If you violate one, something visible breaks.
 
-1. Place new code in the appropriate module file. Bootstrap should stay thin.
-2. All functions: `swh_` prefix. Classes: `SWH_` prefix.
-3. New options → `swh_get_defaults()` in `includes/helpers.php`. They auto-register.
-4. New email templates → both `_sub` and `_body` variants. Support `{if key}...{endif key}` conditionals.
-5. New cron events → register in `swh_activate()`, clear in `swh_deactivate()`.
-6. Schema changes → bump version, add upgrade path in `swh_run_upgrade_routine()`.
-7. Admin-only code stays in `admin/` (gated by `is_admin()` in bootstrap).
-8. i18n: wrap UI strings with `__()`, `esc_html__()`. Do NOT wrap admin-editable defaults.
+1. **`swh_set_ticket_status()` is the only correct way to mutate `_ticket_status`** (v3.7+). Direct `update_post_meta()` bypasses lifecycle hooks. Initial-create sites are the only exception.
+2. **`swh_send_email()` is the only correct mail dispatcher.** Never `wp_mail()` directly — skips template parser, `{if}` blocks, and the HTML wrapper.
+3. **Token comparison uses `hash_equals()`, never `==`.** Applies to portal tokens and inbound-webhook sender check.
+4. **Portal URL ordering:** store `_ticket_token` meta BEFORE calling `swh_get_secure_ticket_link()`. Otherwise it returns false and the email body falls back to a wrong URL.
+5. **Rate-limit keys are per-action with ticket_id:** `portal_close_`, `portal_reopen_`, `portal_reply_` + id. Shared keys block immediate reopen after close.
+6. **No custom DB tables.** All storage is CPT + meta + comments + options + transients. See `docs/internal/data-dictionary.md`.
+7. **Comment isolation:** `comment_type='helpdesk_reply'` segregates ticket activity; internal notes carry `_is_internal_note=1` and must be filtered from frontend.
 
-## Security Conventions
+## Dev commands
 
-- **Nonces:** All forms use `wp_verify_nonce()`.
-- **Capability checks:** `manage_options` for admin, `edit_post` for ticket saves.
-- **Sanitization:** `sanitize_text_field()`, `sanitize_email()`, `wp_kses_post()` for HTML fields.
-- **Escaping:** `esc_html()`, `esc_attr()`, `esc_url()` on all output.
-- **Tokens:** Always `hash_equals()`, never `==`.
-- **Files:** Validate path starts with uploads dir. Serve via `swh_serve_file()` proxy, never direct URLs.
-- **Rate limiting:** Use `swh_get_client_ip()`, never `$_SERVER['REMOTE_ADDR']` directly.
-- **Anti-spam:** Use `swh_check_antispam( $check_captcha )`.
+| Command | What it does |
+|---|---|
+| `make test-docker` | **Required before push** — full PHP gate (lint, PHPCS, PHPStan L9, PHPUnit, Semgrep) inside Docker. Enforced by pre-push hook. |
+| `make e2e-docker` | Self-contained Playwright — spins stack, runs 64 sections, tears down. ~5 min. |
+| `make e2e` | Playwright against an existing stack (`WP_MODE=docker` or SSH vars). |
+| `make js-build` | Build `simple-wp-helpdesk/assets/dist/` from `assets/src/` via `@wordpress/scripts`. |
+| `make bench` | Perf baseline against the Docker stack (`COUNT=N`, default 100). |
+| `make phpcs` / `phpstan` / `phpunit` / `semgrep` | Individual gates. |
+| `vendor/bin/phpcbf && make phpcs` | Auto-fix style then re-check. |
 
-## Common Pitfalls
+Full test-strategy reference and Playwright section taxonomy: `docs/internal/testing-guide.md`.
 
-- **Two settings forms** — main form and Tools form use different nonces. Tools exclusively owns `swh_retention_*` and `swh_delete_on_uninstall`.
-- **Settings save on `admin_init`** — `swh_handle_settings_save()` redirects; never put redirects in the render callback.
-- **Email on ticket save** — `swh_save_ticket_data()` detects changes and sends emails. Use `swh_send_email()` for all mail, never `wp_mail()` directly.
-- **Static cache in `swh_get_defaults()`** — cached per request via `static $defaults`.
-- **Comment isolation** — helpdesk replies use `comment_type = 'helpdesk_reply'`. Internal notes have `_is_internal_note = 1` and must be filtered from frontend.
-- **Cron offsets** — new crons need different offsets to avoid simultaneous execution.
-- **`pre_get_posts` and `meta_key`** — setting it implicitly filters out posts lacking that meta.
-- **Technician restriction** — only filters list query (`pre_get_posts`) and direct access (`load-post.php`). Custom `WP_Query` is NOT filtered.
-- **Token expiration** — pre-v1.9.0 tickets without `_ticket_token_created` are grandfathered (no expiration).
-- **Portal URL** — `swh_get_secure_ticket_link()` uses `swh_ticket_page_id` setting when set (via `get_permalink()`), falling back to `_ticket_url` post meta. Returns `false` if neither is available (token missing or no page configured and no stored meta).
-- **Portal URL ordering** — always store `_ticket_token` in meta *before* calling `swh_get_secure_ticket_link()`; calling it first returns `false` and the fallback URL may point to the wrong page.
-- **Rate limiting keys** — portal actions use per-action keys (`portal_close_`, `portal_reopen_`, `portal_reply_` + ticket_id). Never use a shared key across actions or close will block immediate reopen.
-- **Original filenames** — upload filenames are stored in two parallel locations: `_swh_attachment_orignames` post meta on the ticket (new-ticket uploads, array keyed by file URL) and `_swh_reply_orignames` comment meta on each reply comment (reply/reopen uploads, array keyed by file URL — one meta entry per comment). Fall back to `basename($url)` if missing (pre-v2.3.0 tickets).
-- **CSAT meta** — satisfaction rating stored as `_ticket_csat` (integer 1–5) on the ticket post. Not set if client skips the prompt. AJAX handler registered on `wp_ajax_nopriv_swh_submit_csat`.
-- **My Tickets dashboard** — portal URL without a token shows a ticket table for logged-in WP users (matching `_ticket_email`) or the lookup form for guests. The `swh_render_lookup_form()` helper is shared between the submission shortcode and this view.
-- **Shortcode attributes** — `[submit_ticket]` and `[helpdesk_portal]` accept `show_priority`, `default_priority`, `default_status`, `show_lookup`. Both shortcodes share the same `swh_submit_ticket_shortcode()` handler.
-- **v3.0.0 meta keys** — `_ticket_first_response_at` (Unix timestamp of first staff reply), `_ticket_sla_status` (`warn` or `breach`), `_ticket_cc_emails` (comma-separated CC addresses), `_ticket_template` (label of selected request type at submission).
-- **v3.1.0 meta keys** — `_swh_unread` (`1` when ticket has an unread client reply; cleared when admin opens ticket in editor). Paired with `swh_unread_count` transient (5-min TTL) for badge count performance. Always `delete_transient('swh_unread_count')` after setting or clearing `_swh_unread`.
-- **`helpdesk_category` taxonomy** — registered in `class-installer.php`, hierarchical, `show_admin_column => true`, no REST, no rewrite. Use `wp_set_post_terms()` / `wp_get_post_terms()` to assign/read.
-- **Inbound webhook** — `POST /wp-json/swh/v1/inbound-email`. Validates `Authorization: Bearer <swh_inbound_secret>`. Parses `[TKT-XXXX]` from subject, validates sender vs `_ticket_email` via `hash_equals`. Strips `>`-prefixed quoted lines.
-- **Assignment rules** — stored as JSON in `swh_assignment_rules` option (array of `{category_term_id, assignee_user_id}`). Applied at ticket creation via `swh_apply_assignment_rules()`. First matching rule wins; falls back to `swh_default_assignee`.
-- **SLA cron** — `swh_sla_check_event` runs hourly. Lock transient: `swh_lock_sla`. Open statuses filtered via `swh_sla_open_statuses` filter hook.
-- **Reporting transients** — `swh_report_{type}` cached for `HOUR_IN_SECONDS`. Types: `status_breakdown`, `avg_resolution_time`, `weekly_trend`, `first_response_time`, `kpi`.
-- **`.swh-empty-state`** — shared component in `swh-shared.css`; apply to all "nothing here" states. Three required elements: `.swh-empty-state-icon` (SVG), `.swh-empty-state-title`, `.swh-empty-state-desc`. CTA link is optional.
-- **Dark mode tokens (frontend)** — `swh-shared.css` `@media (prefers-color-scheme: dark)` block. Use `[data-swh-theme="light"]` escape hatch on `.swh-helpdesk-wrapper` for sites that force light mode.
-- **Dark mode tokens (admin, v3.6.0+)** — opt-in per-user via WP `admin_color`. `swh_admin_color_is_dark()` (in `includes/helpers.php`) returns true for `midnight`, `modern`, and `ectoplasm`; admin pages add `swh-admin-theme-dark` to `<body>` so token overrides under `body.swh-helpdesk-admin.swh-admin-theme-dark` in `swh-shared.css` activate. Admin component overrides live in `swh-admin.css` under the same selector.
-- **Email HTML wrapper** — all CSS must be inlined. `swh_wrap_html_email()` in `class-email.php`. No `<link>` or `<style>` tags — email clients strip them.
-- **`swh_email_logo_url` option** — stored in `swh_options` via `swh_get_defaults()`; falls back to `get_site_icon_url(48)` if empty. Displayed at 32×32px in the email header band.
-- **`swh_portal_theme` option** — `'auto'` (default, follows `prefers-color-scheme`) or `'light'` (forces light mode). Output as `data-swh-theme="light"` attribute on every `.swh-helpdesk-wrapper` div in `class-portal.php` and `class-shortcode.php`. The CSS rule `.swh-helpdesk-wrapper[data-swh-theme="light"]` in `swh-shared.css` overrides the dark-mode media query.
-- **Ticket editor panel groups** — `.swh-panel-group` + `.swh-panel-group-label` in `class-ticket-editor.php`. Do NOT change form field `name` attributes or the save handler will break. IDs `#swh-status`, `#swh-priority`, `#swh-assigned-to` must remain.
-- **v3.6.0 conventions** — admin dark-mode selector is exactly `body.swh-helpdesk-admin.swh-admin-theme-dark` (both classes); frontend dark-mode is unchanged (`prefers-color-scheme` + `[data-swh-theme="light"]` escape hatch). Email HTML opt-in to client dark mode via `<meta name="color-scheme" content="light dark">` plus a `@media (prefers-color-scheme: dark)` block in `swh_wrap_html_email()` (still inlined; no `<style>` survives in webmail clients but Apple Mail / iOS Mail honour it).
-- **`swh_render_empty_state()` helper (v3.6.0)** — shared PHP helper in `includes/helpers.php`. Signature: `swh_render_empty_state( $title, $desc, $icon_svg_path, $heading_level = 'h2' )`. Echoes a `.swh-empty-state` block; pass the heading level appropriate to the surrounding hierarchy (admin lists usually `h2`, sub-panels `h3`).
-- **`swh_admin_color_is_dark()` helper (v3.6.0)** — returns `true` when the current user's `admin_color` is one of `midnight`, `modern`, `ectoplasm`. Used by `class-settings.php`, `class-reporting-ui.php`, `class-ticket-list.php` to decide whether to enqueue the dark `<body>` class.
+## PR-time gates
 
-## Release Process
+If your PR touches any of these, update the corresponding internal doc:
 
-1. Determine version using [SemVer](https://semver.org/).
-2. Bump `Version:` header and `SWH_VERSION` in `simple-wp-helpdesk.php`.
-3. Update `CHANGELOG.md` ([Keep a Changelog](https://keepachangelog.com/) format).
-4. Update `simple-wp-helpdesk/readme.txt` stable tag and changelog.
-5. Update `docs/` files for any changed behaviour or new features.
-6. **Run full test suite** (all four must pass — see Test Suite below).
-7. **v4.0+ only:** Run `make bench` against the Docker stack and compare results against `docs/internal/performance-baseline.md`. Document any regressions or improvements in the PR description; significant regressions (>20% on any scenario) require explicit justification.
-8. **Ask the user before creating a PR** — never open one autonomously.
-9. PR from `release/vX.Y.Z` to `main`. Close addressed GitHub issues.
-10. **Run CodeRabbit review** on the PR (`/review`). Address all actionable findings before merge.
-11. Merge to `main`, then push the version tag: `git tag vX.Y.Z && git push origin vX.Y.Z`
-12. `release.yml` workflow triggers automatically — builds `simple-wp-helpdesk.zip` and creates the GitHub Release with CHANGELOG notes attached.
-13. **After pushing, do not monitor CI run status.** Wait for the user to report results before taking further action.
+| Touching… | Update |
+|---|---|
+| Schema-ish state (options, post meta, comment meta, transients, CPT, capabilities) | `data-dictionary.md` |
+| A setting (add/change/remove) | `config-reference.md` |
+| A hook, REST endpoint, AJAX, or shortcode attribute | `api-contract.md` |
+| Untrusted-input handling, auth, files, tokens | `security-model.md` |
+| A shared CSS/JS primitive or design token | `component-inventory.md` |
+| User-facing feature or bug-fix | A new or extended Playwright section (see `testing-guide.md`) |
 
-> ZIP is built by `release.yml` on every `v*.*.*` tag push — no manual zip command needed.
+## Dev environment
 
-## Test Suite
-
-The full test suite must pass before any release. Use `make` targets (requires `composer install` first):
-
-### Local gate (required before opening any PR)
-```bash
-make test-docker  # full gate inside Docker — required (no host PHP fallback)
-make e2e          # Playwright E2E — 64 sections (set WP_MODE=docker or configure SSH vars)
-make e2e-docker   # fully self-contained E2E: up + setup + test + teardown in one command
-make test-all     # make test + make e2e
-```
-
-> **Docker required.** The pre-push hook calls `make test-docker` and aborts if Docker is unavailable. There is no host-PHP fallback.
-
-### Individual tools
-```bash
-make lint        # PHP syntax check on all plugin files
-make phpcs       # WordPress Coding Standards (zero errors/warnings required)
-vendor/bin/phpcbf && make phpcs   # auto-fix then re-check
-make phpstan     # PHPStan level 9 (PHP 8.1+ required)
-make phpunit     # PHPUnit unit tests
-make semgrep     # Semgrep SAST scan
-make coverage    # PHPUnit coverage → coverage.xml (requires pcov or xdebug)
-```
-
-### Docker test stack (local or CI)
-
-```bash
-# Fully self-contained — one command spins up, runs all 56 E2E sections, tears down
-make e2e-docker
-
-# Or manually:
-docker compose -f docker-compose.test.yml up -d db wordpress wpcli mailhog
-bash docker/setup-test-wp.sh
-WP_MODE=docker MAILHOG_URL=http://localhost:8025 make e2e
-docker compose -f docker-compose.test.yml down -v
-```
-
-**MailHog:** When `MAILHOG_URL` is set and `WP_MODE=docker`, `expect_email()` calls in the test suite assert email delivery automatically via the MailHog API (`http://localhost:8025`). In SSH mode, `expect_email()` falls back to the manual `EMAIL_CHECKS` summary printed after the run.
-
-### 5. CodeRabbit — AI code review (on PR)
-Run `/review` after opening the PR. Address all actionable findings before merge.
-
-## Development Commands
-
-```bash
-# Quick smoke check (auth, submit, locate)
-pytest testing/scripts/test_helpdesk_pw.py -m smoke
-
-# Security tests only
-pytest testing/scripts/test_helpdesk_pw.py -m security
-
-# Single section
-pytest testing/scripts/test_helpdesk_pw.py -k "test_19"
-
-# Visible browser / slow-motion debug
-pytest testing/scripts/test_helpdesk_pw.py --headed --slowmo 500
-
-# Run against local Docker stack instead of SSH dev server
-WP_MODE=docker pytest testing/scripts/test_helpdesk_pw.py -v
-```
-
-## Playwright Test Suite
-
-**Location:** `testing/scripts/test_helpdesk_pw.py`
-**Config:** `testing/pytest.ini`, `testing/scripts/conftest.py`
-**Requirements:** `testing/requirements.txt` (playwright 1.59, pytest 9, pytest-playwright 0.7.2)
-**Screenshots:** `testing/screenshots/`
-
-### 64 test sections (34 original + 11 v3.0.0 + 7 v3.1.0 + 1 v3.2.0 + 1 v3.3.0 + 2 v3.4.0 + 2 v3.5.0 + 6 v3.6.0)
-
-| # | Name | Marks |
-|---|------|-------|
-| 01 | admin_auth | smoke |
-| 02 | plugin_verification | smoke |
-| 03 | ticket_submission | smoke |
-| 04 | admin_locate_ticket | smoke |
-| 05 | portal_url | |
-| 06 | admin_update_ticket | |
-| 07 | technician_workflow | |
-| 08 | client_portal | |
-| 09 | admin_verify_reply | |
-| 10 | portal_close_reopen | |
-| 11 | access_control | |
-| 12 | ticket_list_filters | |
-| 13 | ticket_lookup | |
-| 14 | accessibility | |
-| 15 | plugin_icons | slow |
-| 16 | honeypot_spam | security |
-| 17 | form_validation | security |
-| 18 | settings_persistence | |
-| 19 | canned_responses | |
-| 20 | bulk_status_change | |
-| 21 | tech2_workflow | |
-| 22 | admin_search_and_filters | |
-| 23 | file_attachments | slow |
-| 24 | portal_token_security | security |
-| 25 | xss_escaping | security |
-| 26 | subscriber_access_control | security |
-| 27 | rate_limiting | security |
-| 29 | humanized_timestamps | |
-| 30 | resolved_cta_layout | |
-| 33 | csat_prompt | |
-| 34 | my_tickets_dashboard | |
-| 35 | portal_guest_lookup | |
-| 36 | shortcode_attrs | |
-| 37 | admin_list_filtering | |
-| 38 | admin_list_sorting | |
-| 39 | ticket_templates | |
-| 40 | first_response_time | |
-| 41 | cc_watchers | |
-| 42 | categories_taxonomy | |
-| 43 | ticket_merge | |
-| 44 | sla_breach_detection | |
-| 45 | assignment_rules | |
-| 46 | reporting_dashboard | |
-| 47 | inbound_email_webhook | |
-| 48 | timestamp_locale | |
-| 49 | dedicated_reply_buttons | |
-| 50 | unread_badge | |
-| 51 | unread_row_highlight | |
-| 52 | email_test_button | |
-| 53 | ux_a11y | |
-| 54 | responsive | |
-| 55 | email_branding | |
-| 56 | dark_mode | |
-| 57 | toast_notifications | |
-| 58 | reports_loading_states | |
-| 59 | admin_dark_mode | |
-| 60 | email_color_scheme | |
-| 61 | skip_to_content | |
-| 62 | focus_visible_rings | |
-| 63 | csat_focus_management | |
-| 64 | aria_live_announcements | |
-| 28 | cleanup | |
-
-### Architecture
-
-- **Session-scoped browser** — single Chromium instance shared across all tests (login cookies persist)
-- **`check()`** — soft-fail helper; failures accumulate and surface after each test via `conftest.py` autouse fixture
-- **`skip()`** — records a skip without aborting
-- **`as_user(page, user, pass)`** — context manager: logout → login → yield → logout
-- **`wpcli(cmd)`** — runs WP-CLI via SSH+docker exec (default) or `docker compose exec` when `WP_MODE=docker`
-- **`_clear_rate_limits()`** — deletes `swh_rl_*` rows from wp_options + flushes object cache (rate limiter uses `get_option()` which checks cache first)
-- **`_navigate_settings(page)`** — navigates to settings page and removes `.wp-pointer` elements (Security Ninja and other admin pointers intercept clicks)
-- **`state` dict** — carries `ticket_id`, `ticket2_id`, `portal_url` etc. across sections
-- **`EMAIL_CHECKS` list** — printed at end of run; manually verify via Gmail MCP
-
-### Key gotchas
-
-- **Meta key is `_ticket_status`** (underscore prefix) — `wp post meta get` returns empty; use `wp eval 'echo get_post_meta(ID, "_ticket_status", true);'`
-- **`required` attributes** — strip before JS form submit in validation tests or the POST never reaches the server (HTML5 browser validation intercepts it)
-- **WordPress word-level search** — `LIKE '%Ticket%'` matches both "Ticket" and "Ticket2"; avoid negative assertions based on title substrings
-- **WP admin pointers** — Security Ninja and other plugins inject `.wp-pointer` overlays that intercept Playwright clicks; `_navigate_settings()` removes them on every settings page visit
-- **Bulk action key format** — `sanitize_title('In Progress')` → `in-progress` → action value `swh_status_in-progress`
-- **`expect_navigation()`** — wrap JS-triggered form submits in `with page.expect_navigation():` to avoid race between evaluate and `page.content()`
-- **Canned response persistence check** — use `el.value` via `page.evaluate()`, not `inner_text()` (input values aren't in innerText)
-- **File upload form POST** — a page caching plugin fires an immediate GET after the file POST, overwriting the success HTML in the DOM. Use `expect_navigation()` + `wait_for_load_state("load")` to let it settle, then verify success via WP-CLI meta rather than `page.content()`
-- **`wpcli()` exits non-zero for absent data** — `wp option get`, `wp post meta get`, `wp comment meta get` all exit 1 when the key/meta is absent. This is a normal result (not an infrastructure error); `wpcli()` returns empty string and callers handle it via `check()`. Do NOT raise on non-zero in the helper.
-- **Authorization header stripped in Docker** — Apache drops the `Authorization` header before PHP receives it, regardless of `.htaccess` passthrough rules. For test_47 (inbound webhook), bypass HTTP entirely: construct a `WP_REST_Request` and call `swh_handle_inbound_email()` directly via `wp eval`.
-
-### Environment variables (testing/.env)
-
-Copy `testing/.env.example` to `testing/.env` and fill in values. See the example file for descriptions of every variable.
-
-```
-WP_URL, WP_LOGIN_URL, WP_ADMIN_URL, WP_SUBMIT_PAGE, WP_PORTAL_PAGE
-WP_ADMIN_USER, WP_ADMIN_PASS
-WP_TECH1_EMAIL, WP_TECH1_USER, WP_TECH1_PASS
-WP_TECH2_USER, WP_TECH2_PASS
-CLIENT1_NAME, CLIENT1_EMAIL
-CLIENT2_NAME, CLIENT2_EMAIL
-WP_MODE          — "ssh" (default, local dev server) or "docker" (local/CI Docker stack)
-SSH_HOST, WP_CONTAINER, WP_PATH   — required when WP_MODE=ssh
-MAILHOG_URL      — MailHog API base URL (e.g. http://localhost:8025); enables automated email assertions when WP_MODE=docker
-```
-
-### Test update policy
-
-Every PR that introduces user-facing changes **must** include a new or updated Playwright test section.
-
-| Change type | Required test |
-|-------------|---------------|
-| New user-facing feature | New numbered section in `test_helpdesk_pw.py` |
-| Bug fix (regression) | New or extended section covering the bug scenario |
-| Admin-only UI change | New or extended admin section |
-| Internal refactor, no UX change | None required — existing sections must still pass |
-| Security fix | Extend or add a `security`-marked section |
-
-New sections continue from the next available number (currently 65). Add the section to the table above.
-
-## Dev Tools
-
-### Static Analysis & Test Gate
+### Static analysis & test gate
 
 | Tool | Command | Notes |
-|------|---------|-------|
-| **Local gate (Docker)** | `make test-docker` | Full gate inside phptest container — no host PHP/semgrep needed (preferred) |
-| **Local gate (host)** | `make test` | Runs lint → phpcs → phpstan → phpunit → semgrep; requires host PHP 8.1+, semgrep |
-| **E2E** | `make e2e` | Playwright suite; set `WP_MODE=docker` or configure SSH vars |
-| **E2E (self-contained)** | `make e2e-docker` | Spins up Docker stack + setup + E2E + teardown in one command |
+|---|---|---|
+| Local gate (Docker) | `make test-docker` | Preferred — no host PHP/semgrep needed |
+| Local gate (host) | `make test` | Requires host PHP 8.1+, semgrep |
 | PHPStan | `make phpstan` | Level 9, WP stubs via `szepeviktor/phpstan-wordpress` |
-| PHPUnit | `make phpunit` | Unit tests in `tests/Unit/`; WP-Mock (`10up/wp_mock`) for WordPress function stubs |
-| Coverage | `make coverage` | PHPUnit + pcov → `coverage.xml` (Clover); requires pcov or xdebug |
-| Semgrep | `make semgrep` / MCP `semgrep_scan` | SAST; also runs in CI via `.github/workflows/semgrep.yml` |
-| Docker stack | `docker compose -f docker-compose.test.yml up -d` | Local WP + MySQL + MailHog; `bash docker/setup-test-wp.sh` to configure |
+| PHPUnit | `make phpunit` | `tests/Unit/`; WP-Mock for WP stubs |
+| Coverage | `make coverage` | Clover XML; requires pcov or xdebug |
+| Semgrep | `make semgrep` / MCP `semgrep_scan` | SAST; also CI via `.github/workflows/semgrep.yml` |
 
 ### LSP (Language Intelligence)
 
 Configured in `.vscode/settings.json` and `testing/pyrightconfig.json`.
 
 | Language | Server | Binary | Notes |
-|----------|--------|--------|-------|
+|---|---|---|---|
 | PHP | Intelephense | `intelephense` (npm global) | WP stubs from `vendor/php-stubs/wordpress-stubs/` via `intelephense.environment.includePaths` |
-| Python | Pyright | `pyright` (npm global) | Venv: `testing/.venv`; configured via `testing/pyrightconfig.json` |
-| TypeScript | typescript-language-server | `typescript-language-server` (npm global) | |
+| Python | Pyright | `pyright` (npm global) | Venv: `testing/.venv`; `testing/pyrightconfig.json` |
+| TypeScript | typescript-language-server | (npm global) | |
 
-LSP operations available: `goToDefinition`, `findReferences`, `hover`, `documentSymbol`, `workspaceSymbol`, `goToImplementation`, `prepareCallHierarchy`, `incomingCalls`, `outgoingCalls`.
+LSP operations: `goToDefinition`, `findReferences`, `hover`, `documentSymbol`, `workspaceSymbol`, `goToImplementation`, `prepareCallHierarchy`, `incomingCalls`, `outgoingCalls`.
 
 ### MCP Servers
 
-| Server | Purpose |
-|--------|---------|
-| `playwright` (npx) | Browser automation |
-| `github` | GitHub API — issues, PRs, code search |
-| Docker MCP gateway | Aggregates 11 servers (see below) |
-
-**Docker MCP gateway servers:**
-
-| Name | Purpose |
-|------|---------|
-| `github-official` | GitHub (OAuth) |
-| `context7` | Up-to-date library/framework docs |
-| `microsoft-learn` | Microsoft/Azure docs |
-| `memory` | Knowledge graph persistent memory |
-| `playwright` | Browser automation (Docker instance) |
-| `aws-documentation` | AWS docs search |
-| `node-code-sandbox` | Node.js sandbox execution |
-| `sqlite-mcp-server` | SQLite as a tool |
-| `dockerhub` | Docker Hub |
-| `mcp-python-refactoring` | Python refactoring assistant |
-| `next-devtools-mcp` | Next.js dev tools |
+`playwright` (npx) · `github` · Docker MCP gateway (aggregates 11: `github-official`, `context7`, `microsoft-learn`, `memory`, `playwright`, `aws-documentation`, `node-code-sandbox`, `sqlite-mcp-server`, `dockerhub`, `mcp-python-refactoring`, `next-devtools-mcp`).
 
 ### Plugins & Slash Commands
 
 | Command | Plugin | Purpose |
-|---------|--------|---------|
+|---|---|---|
 | `/commit` | commit-commands | Create a git commit |
 | `/commit-push-pr` | commit-commands | Commit + push + open PR |
 | `/clean_gone` | commit-commands | Delete gone branches |
@@ -378,7 +113,7 @@ LSP operations available: `goToDefinition`, `findReferences`, `hover`, `document
 ### Plugin-provided agents (via Agent tool)
 
 | Agent | Plugin | Purpose |
-|-------|--------|---------|
+|---|---|---|
 | `pr-review-toolkit:code-reviewer` | pr-review-toolkit | Code quality + style |
 | `pr-review-toolkit:silent-failure-hunter` | pr-review-toolkit | Error handling gaps |
 | `pr-review-toolkit:code-simplifier` | pr-review-toolkit | Simplify after writing code |
@@ -391,7 +126,7 @@ LSP operations available: `goToDefinition`, `findReferences`, `hover`, `document
 
 ## GitHub Auto-Updater
 
-Uses [plugin-update-checker](https://github.com/YahnisElsts/plugin-update-checker) (bundled in `vendor/`). Initialized in bootstrap with `PucFactory::buildUpdateChecker()`. Branch: `main`. Supports release assets and API token auth.
+Uses [plugin-update-checker](https://github.com/YahnisElsts/plugin-update-checker) (bundled in `simple-wp-helpdesk/vendor/`). Initialized in bootstrap with `PucFactory::buildUpdateChecker()`. Branch: `main`. Supports release assets and API token auth.
 
 # Compact instructions
 

--- a/docs/internal/README.md
+++ b/docs/internal/README.md
@@ -1,0 +1,77 @@
+# `docs/internal/` — Developer & Agent Documentation
+
+This directory is the developer- and agent-facing knowledge base for Simple WP Helpdesk. It documents **why** the code is the way it is, what constraints it preserves, and how to extend it safely.
+
+It is **not** end-user documentation.
+
+## What lives here vs `docs/` proper
+
+| Location | Audience | Content |
+|---|---|---|
+| `docs/` (root of) | Operators, site admins, integrators using the plugin | How to install, configure, use, troubleshoot. Public hook reference. |
+| `docs/developer/` | Integrators writing PHP against the plugin | Public action/filter hook signatures and deprecation policy. |
+| `docs/internal/` | Plugin contributors and AI coding agents | Architecture, invariants, conventions, internal data model, test strategy. |
+
+When in doubt: if the reader is *using* the plugin, it belongs in `docs/`. If the reader is *modifying* the plugin, it belongs here.
+
+## Reading order for a new contributor
+
+1. **[design-document.md](design-document.md)** — architecture, repository layout, load-bearing invariants.
+2. **[coding-guide.md](coding-guide.md)** — naming, security, escaping, comments, PR-time gates.
+3. **[testing-guide.md](testing-guide.md)** — test layers, how to run, when to add what.
+4. **[security-model.md](security-model.md)** — trust boundaries and threat model.
+5. **[api-contract.md](api-contract.md)** — what is public and what may change.
+6. **[data-dictionary.md](data-dictionary.md)** — every meta key, option, transient, capability.
+7. **[config-reference.md](config-reference.md)** — operator-tunable options.
+8. **[design-guide.md](design-guide.md)** — UX/UI principles. Defers component-level detail to `component-inventory.md`.
+
+## Routing — when in doubt
+
+| You are about to … | Read first | Then update |
+|---|---|---|
+| Add a new option / setting | `config-reference.md` | `config-reference.md` + `data-dictionary.md` |
+| Add/rename/remove a post-meta key | `data-dictionary.md`, `design-document.md` invariants | `data-dictionary.md` + upgrade routine in `class-installer.php` |
+| Add/rename/remove a hook (`do_action`/`apply_filters`) | `api-contract.md`, `docs/developer/hooks.md` | `docs/developer/hooks.md` + `api-contract.md` |
+| Add a REST endpoint | `api-contract.md`, `security-model.md` | both |
+| Add a Playwright section | `testing-guide.md` | `testing-guide.md` taxonomy table |
+| Touch ticket status logic | `design-document.md` invariant on `swh_set_ticket_status` | none if invariant respected |
+| Touch file upload / serving | `security-model.md` | `security-model.md` if posture changes |
+| Add a UI primitive / token | `component-inventory.md` | `component-inventory.md` |
+| Add JS | `js-architecture.md` | `js-architecture.md` |
+| Answer "is X already known to be a bug?" | Memory MCP (`search_nodes`) | n/a |
+| Operator-facing question ("how do I configure X?") | `docs/configuration.md` | `docs/` proper, not here |
+
+## All internal docs
+
+### New in this set (authoritative starting point)
+
+- `README.md` (this file) — index + routing.
+- `design-document.md` — architecture, module map, load-bearing invariants, release engineering.
+- `coding-guide.md` — naming, security, escaping, comments, PR-time gates.
+- `testing-guide.md` — PHPUnit, Playwright, CI, environment variables.
+- `security-model.md` — trust boundaries, threats, capability matrix.
+- `api-contract.md` — public surface, versioning policy, breaking-change taxonomy.
+- `data-dictionary.md` — every WP storage primitive the plugin owns.
+- `config-reference.md` — `swh_get_defaults()` exhaustive reference.
+- `design-guide.md` — UX/UI principles; defers to `component-inventory.md`.
+
+### Pre-existing authoritative docs (do not duplicate)
+
+- `component-inventory.md` — UI primitives, CSS classes, design tokens. Source of truth for UI vocabulary.
+- `js-architecture.md` — `@wordpress/scripts` build, vanilla JS conventions, toast module.
+- `performance-baseline.md` — measured baselines for ticket list / portal / settings.
+- `release_v3.x.x_roadmap.md` — planned work for the v3.x line.
+- `release_v4.x.x_roadmap.md` — planned work for the v4.x line.
+- `parked_features.md` — explicitly deferred ideas.
+- `lessons-learned.md` — incident retrospectives and "don't do this again" notes.
+- `new_features_discussion.md` — open design questions.
+- `plan_v3.7.0.md`, `v3.7.0-discovery.md`, `v3.7.0-issue-snapshots/` — v3.7.0 release-planning artifacts; historical, not maintained going forward.
+
+## Update protocol
+
+Update this file when:
+- A new doc is added to `docs/internal/`.
+- A doc is renamed or its scope materially changes.
+- A new "routing" trigger surfaces (e.g. "every time I want to do X I have to remember which doc covers it").
+
+This is the table of contents. If it falls out of date the rest of the set decays. Treat broken routing entries as bugs.

--- a/docs/internal/api-contract.md
+++ b/docs/internal/api-contract.md
@@ -1,0 +1,153 @@
+# API Contract
+
+**Audience:** integrators writing PHP against the plugin, and contributors changing the plugin's public surface.
+
+## What is public, what is internal
+
+**Public** (covered by the SemVer policy below):
+
+- Action hooks documented in `docs/developer/hooks.md`.
+- Filter hooks listed under "Filter hooks" in this doc.
+- The REST endpoint `POST /wp-json/swh/v1/inbound-email`.
+- The `nopriv` AJAX endpoint `wp_ajax_nopriv_swh_submit_csat`.
+- Shortcodes `[submit_ticket]` and `[helpdesk_portal]` with their documented attributes.
+- Constants `SWH_VERSION`, `SWH_PLUGIN_DIR`, `SWH_PLUGIN_URL`, `SWH_PLUGIN_FILE`.
+- Helper functions documented with `@since` in PHPDoc and called from outside their defining file (e.g. `swh_get_secure_ticket_link`, `swh_send_email`, `swh_set_ticket_status`, `swh_render_empty_state`).
+
+**Internal** (may change in any release):
+
+- Functions and classes not listed above. Even if they have `swh_` prefix.
+- Database schema beyond what `data-dictionary.md` documents.
+- Admin AJAX endpoints (`wp_ajax_swh_merge_ticket`, `wp_ajax_swh_send_test_email`, `wp_ajax_swh_report_data`) — these are admin-only and gated by `manage_options`.
+- CSS class names beyond those in `component-inventory.md`.
+- The "advisory" group argument to `swh_get_option()` — it is intentionally ignored in v3.7 and consumed by v4.0 schema migration.
+
+If you depend on an internal API, pin to a version and read the changelog before upgrading.
+
+## Versioning policy
+
+[SemVer](https://semver.org/). Breaking-change taxonomy:
+
+| Change | Bump |
+|---|---|
+| Removing a public hook | MAJOR |
+| Renaming a public hook | MAJOR |
+| Changing a public hook signature (arg count, arg order, arg type) | MAJOR |
+| Adding a public hook | MINOR |
+| Removing a setting | MAJOR (operator-visible) |
+| Changing a setting's default in a way that alters runtime behaviour | MAJOR |
+| Adding a setting | MINOR |
+| Changing a REST endpoint URL | MAJOR |
+| Adding a REST endpoint or new query/body parameter | MINOR |
+| Changing a shortcode attribute default | MAJOR |
+| Adding a shortcode attribute | MINOR |
+| Removing a meta key without an upgrade routine | MAJOR |
+| Adding a meta key | MINOR |
+| Bug fixes / internal refactor with no external surface change | PATCH |
+
+When MAJOR is unavoidable, the previous behaviour is wrapped in `simple-wp-helpdesk/includes/deprecations.php` so old hooks fire alongside new ones for at least one MAJOR cycle. See `docs/developer/deprecations.md`.
+
+## Action hooks
+
+Listed in `docs/developer/hooks.md`. Enumerated for reference:
+
+| Hook | Signature | Since |
+|---|---|---|
+| `swh_pre_ticket_create` | `(array $data)` | 2.1.0 |
+| `swh_ticket_created` | `(int $ticket_id, array $data)` | 2.1.0 |
+| `swh_ticket_status_changed` | `(int $ticket_id, string $old_status, string $new_status)` | 3.7.0 |
+| `swh_ticket_closed` | `(int $ticket_id, string $previous_status)` | 3.7.0 |
+| `swh_ticket_reopened` | `(int $ticket_id, string $previous_status)` | 3.7.0 |
+| `swh_ticket_replied` | `(int $ticket_id, int $comment_id, bool $is_staff_reply)` | 3.7.0 |
+| `swh_ticket_assigned` | `(int $ticket_id, int $old_user_id, int $new_user_id)` | 3.7.0 |
+| `swh_csat_submitted` | `(int $ticket_id, int $rating)` | 3.0.0 |
+| `swh_sla_breached` | `(int $ticket_id, int $minutes_over)` | 3.0.0 |
+
+See `docs/developer/hooks.md` for usage examples and full documentation.
+
+## Filter hooks
+
+Enumerated from `grep -rn "apply_filters(\s*['\"]swh_" simple-wp-helpdesk/`:
+
+| Hook | Signature | Purpose | Location |
+|---|---|---|---|
+| `swh_ticket_statuses` | `(string[] $statuses) -> string[]` | Override the available ticket status labels. | `includes/helpers.php:278` |
+| `swh_ticket_priorities` | `(string[] $priorities) -> string[]` | Override the available priority labels. | `includes/helpers.php:296` |
+| `swh_allowed_file_types` | `(string[] $extensions) -> string[]` | Override the upload extension allowlist (default `jpg, jpeg, jpe, png, gif, pdf, doc, docx, txt`). Applied at both submit and reply upload paths. | `frontend/class-shortcode.php:57, 517` |
+| `swh_submission_data` | `(array $data) -> array` | Mutate sanitized submission fields before insert. Fires after sanitization, before `swh_pre_ticket_create`. | `frontend/class-shortcode.php:186` |
+| `swh_autoclose_threshold` | `(int $days) -> int` | Override the auto-close threshold (default `swh_autoclose_days` option). | `includes/class-cron.php:51` |
+| `swh_sla_open_statuses` | `(string[] $statuses) -> string[]` | Statuses considered "open" by the SLA cron. | `includes/class-cron.php:343` |
+| `swh_rate_limit_ttl` | `(int $ttl, string $action) -> int` | Override the rate-limit TTL per action. | `includes/helpers.php:785` |
+| `swh_parse_template` | `(string $rendered, array $data) -> string` | Post-process a parsed email template body or subject. | `includes/class-email.php:69` |
+| `swh_email_headers` | `(string[] $headers, string $to, string $subject) -> string[]` | Add or replace email headers. Canonical place to add Reply-To, BCC, or X-* headers. | `includes/class-email.php:109` |
+
+## REST endpoints
+
+| Method | Path | Auth | Body | Response |
+|---|---|---|---|---|
+| `POST` | `/wp-json/swh/v1/inbound-email` | `Authorization: Bearer <swh_inbound_secret>` header. `permission_callback` is `__return_true` (auth enforced inside the handler). | Parsed-email JSON; the handler reads `from`, `subject`, `body`. Subject must contain `[TKT-XXXX]`. Sender email is compared to `_ticket_email` of the matched ticket via `hash_equals`. | `200` on accepted reply; `4xx` on auth / parse / match failure. |
+
+Registered at `simple-wp-helpdesk/simple-wp-helpdesk.php:213`. Handler at `simple-wp-helpdesk/includes/class-email.php:222`.
+
+**Idempotency:** the handler does not de-duplicate inbound messages; the upstream MTA / inbound-parse provider is responsible for at-most-once delivery. The handler is safe to call repeatedly — it will insert a reply comment each time.
+
+**Authorization header note:** Apache running in front of PHP-FPM strips the `Authorization` header by default. Operators must configure `.htaccess` or vhost to pass it through, or use a server-internal call path. Test section 47 documents the bypass used in CI (calling `swh_handle_inbound_email()` directly via `wp eval`).
+
+## AJAX endpoints
+
+| Action | Auth | Purpose |
+|---|---|---|
+| `wp_ajax_nopriv_swh_submit_csat` (also `wp_ajax_swh_submit_csat`) | nonce | Records a 1–5 CSAT rating into `_ticket_csat` post meta. **Public surface.** | 
+| `wp_ajax_swh_merge_ticket` | `manage_options` + nonce | Admin-only ticket merge. **Internal.** |
+| `wp_ajax_swh_send_test_email` | `manage_options` + nonce | Admin-only test email sender. **Internal.** |
+| `wp_ajax_swh_report_data` | `manage_options` + nonce | Reporting data fetch with transient caching. **Internal.** |
+
+Registered:
+
+- `class-ticket.php:391-392` — CSAT.
+- `simple-wp-helpdesk.php:173` — merge.
+- `admin/class-settings.php:1035` — test email.
+- `admin/class-reporting.php:12` — report data.
+
+## Shortcodes
+
+Both shortcodes are dispatched by the same handler `swh_submit_ticket_shortcode()` in `frontend/class-shortcode.php`.
+
+| Shortcode | Attribute | Default | Effect |
+|---|---|---|---|
+| `[submit_ticket]` | `show_priority` | `yes` | Show/hide the priority select field. |
+| `[submit_ticket]` | `default_priority` | `Medium` (from `swh_default_priority`) | Pre-select a priority value. |
+| `[submit_ticket]` | `default_status` | `Open` (from `swh_default_status`) | Pre-set the new ticket status on save. |
+| `[submit_ticket]` | `show_lookup` | `yes` | Show/hide the "lost your link?" lookup form below the submit form. |
+| `[helpdesk_portal]` | (same attributes) | | When the URL lacks a `token`, renders either the My Tickets dashboard (logged-in users) or the lookup form (guests). |
+
+## Constants
+
+| Constant | Type | Source of truth |
+|---|---|---|
+| `SWH_VERSION` | string | `simple-wp-helpdesk/simple-wp-helpdesk.php:19` |
+| `SWH_PLUGIN_DIR` | string | bootstrap |
+| `SWH_PLUGIN_URL` | string | bootstrap |
+| `SWH_PLUGIN_FILE` | string | bootstrap |
+| `SWH_ICON_1X`, `SWH_ICON_2X`, `SWH_MENU_ICON` | string | bootstrap (icon URLs) |
+
+These are guaranteed across releases. Renaming or removing any of them is MAJOR.
+
+## Deprecation policy
+
+When a public hook or function must be removed:
+
+1. The new replacement ships first, in a MINOR release.
+2. The old name continues to fire (or function) for at least one MAJOR cycle, implemented in `simple-wp-helpdesk/includes/deprecations.php`.
+3. Each shim calls `_deprecated_hook()` or `_deprecated_function()` once per page load (WP's own throttle) so debug logs surface usage.
+4. The shim is removed only in the MAJOR release **after** the introduction MAJOR.
+
+See `docs/developer/deprecations.md` for the current shim list.
+
+## Update protocol
+
+Update this doc when:
+- Any item in the "public surface" lists above is added, removed, renamed, or changes signature.
+- A new filter hook is introduced — add a row to the filter table.
+- The SemVer taxonomy is amended.
+- A deprecation enters or leaves `includes/deprecations.php`.

--- a/docs/internal/coding-guide.md
+++ b/docs/internal/coding-guide.md
@@ -44,7 +44,7 @@ Each rule below is enforced by automation, code review, or both. See `security-m
 
 | Rule | One-liner |
 |---|---|
-| Nonces | Every form/AJAX/REST handler verifies a WP nonce via `wp_verify_nonce()` or `check_ajax_referer()`. |
+| Nonces | Every form, AJAX, and **cookie-authenticated** REST handler verifies a WP nonce via `wp_verify_nonce()` or `check_ajax_referer()`. Token-authenticated REST endpoints (e.g. the inbound-email Bearer endpoint, `class-email.php`) verify the token with `hash_equals()` instead — they have no cookie context for a nonce. |
 | Capability checks | `manage_options` for plugin-admin actions; `edit_post` for ticket-specific actions; REST and AJAX always check after the nonce. |
 | Token compare | Always `hash_equals( $expected, $provided )`. Never `==` or `===` on token strings. |
 | Client IP | Always `swh_get_client_ip()`. Never `$_SERVER['REMOTE_ADDR']` directly. |

--- a/docs/internal/coding-guide.md
+++ b/docs/internal/coding-guide.md
@@ -1,0 +1,162 @@
+# Coding Guide
+
+**Audience:** plugin contributors.
+
+This is the project's coding-conventions reference. Style is enforced by automation (PHPCS / PHPStan / Semgrep / pre-push hook); this doc explains the **why** behind the rules and the patterns that automation cannot enforce.
+
+## Language baseline
+
+| Layer | Version floor | Source |
+|---|---|---|
+| PHP | 7.4 | `Requires PHP:` header in `simple-wp-helpdesk/simple-wp-helpdesk.php:7`. |
+| WordPress | 5.3 | `Requires at least:` in the same header. |
+| PHPStan | level 9 | `phpstan.neon`. Requires PHP 8.1+ to run (dev-time). |
+| PHPCS ruleset | WordPress Coding Standards | `.phpcs.xml`. Zero errors and zero warnings required. |
+| JS build | `@wordpress/scripts` | `package.json`. Output to `simple-wp-helpdesk/assets/dist/`. Vanilla JS — no JSX in the current PoC. |
+
+We do not use features beyond the PHP 7.4 baseline in shipped plugin code. Dev-time tooling (PHPStan, PHPUnit) may require newer PHP.
+
+## Naming
+
+| Kind | Prefix / convention | Example |
+|---|---|---|
+| Global function | `swh_` snake_case | `swh_get_defaults()`, `swh_send_email()` |
+| Legacy class | `SWH_` PascalCase | (legacy; minimal usage) |
+| PSR-4 namespaced class (v3.7+) | `SWH\…` | `SWH\Foo\Bar` under `simple-wp-helpdesk/src/` |
+| Custom post type slug | snake_case literal | `helpdesk_ticket` |
+| Comment type | snake_case literal | `helpdesk_reply` |
+| Taxonomy slug | snake_case literal | `helpdesk_category` |
+| Option | `swh_` prefix | `swh_default_priority` |
+| Post meta | `_ticket_` or `_swh_` prefix (leading underscore = hidden) | `_ticket_status`, `_swh_unread` |
+| Comment meta | `_is_*` or `_swh_*` | `_is_internal_note`, `_swh_reply_orignames` |
+| Transient | `swh_` prefix | `swh_unread_count`, `swh_report_*` |
+| Rate-limit key (stored as option) | `swh_rl_` + md5 | `swh_rl_<hash>` |
+| Cron lock transient | `swh_lock_` + slug | `swh_lock_autoclose` |
+| Capability | `edit_helpdesk_tickets` style (custom) or post caps | granted via Technician role in `class-installer.php:18-41` |
+| CSS class | `swh-` kebab-case | `swh-empty-state`, `swh-panel-group` |
+| JS handle | `swh-` kebab-case | `swh-toast` |
+
+The uninstall sweep at `class-installer.php:226-229` relies on these prefixes. A mis-prefixed key will persist forever.
+
+## Security conventions (hot list)
+
+Each rule below is enforced by automation, code review, or both. See `security-model.md` for rationale and trust boundaries.
+
+| Rule | One-liner |
+|---|---|
+| Nonces | Every form/AJAX/REST handler verifies a WP nonce via `wp_verify_nonce()` or `check_ajax_referer()`. |
+| Capability checks | `manage_options` for plugin-admin actions; `edit_post` for ticket-specific actions; REST and AJAX always check after the nonce. |
+| Token compare | Always `hash_equals( $expected, $provided )`. Never `==` or `===` on token strings. |
+| Client IP | Always `swh_get_client_ip()`. Never `$_SERVER['REMOTE_ADDR']` directly. |
+| File serving | Always through `swh_serve_file()`. Path must resolve inside `wp_get_upload_dir()['basedir']`. |
+| Anti-spam | Public POST handlers call `swh_check_antispam( $check_captcha )` before persisting. |
+| Rate limiting | Public POST handlers call `swh_is_rate_limited( $per_action_key )` before persisting. |
+| Closed-defaults | Misconfigured reCAPTCHA / Turnstile fails **closed** — see `helpers.php:392-393, 404`. |
+
+## Sanitization and escaping
+
+Sanitize on input; escape on output. Pick the function that matches the destination:
+
+| Untrusted input → | Function | Notes |
+|---|---|---|
+| Plain text (single line) | `sanitize_text_field()` | strips tags, normalises whitespace |
+| Email address | `sanitize_email()` | combine with `is_email()` for validation |
+| Integer ID | `absint()` | for non-negative ints; `intval()` for signed |
+| HTML body (admin-only) | `wp_kses_post()` | retains the WP post allowlist |
+| File name | `sanitize_file_name()` | use before storing or echoing |
+| Slug | `sanitize_title()` | bulk action keys derive from this |
+| Raw POST scalar | `wp_unslash()` then sanitize | always unslash before passing to a sanitizer |
+
+| Output context → | Function |
+|---|---|
+| HTML text node | `esc_html()` |
+| HTML attribute value | `esc_attr()` |
+| URL | `esc_url()` (rendered) or `esc_url_raw()` (stored) |
+| Translation string with HTML | `wp_kses()` with explicit allowlist |
+| JSON | `wp_send_json_*()` / `wp_json_encode()` — both escape correctly |
+
+Calling sites worth reading as canonical examples: `swh_get_client_ip()` at `helpers.php:356-365` (input), `swh_render_empty_state()` at `helpers.php:811-828` (output, with `wp_kses` allowlist for an inline SVG).
+
+## Error handling
+
+The project prefers explicit early-return guards over try/catch in PHP.
+
+- **WP API failures:** check `is_wp_error()` on every `wp_remote_*`, `wp_insert_*`, `wp_update_*` return.
+- **AJAX failures:** return via `wp_send_json_error( array( 'message' => __( '…', 'simple-wp-helpdesk' ) ), $http_status )`. Always include a translatable message and a status code.
+- **REST failures:** return `new WP_Error( $code, $message, array( 'status' => $http_status ) )`.
+- **Silent fallback:** acceptable only when the surface is genuinely cosmetic (e.g. attachment origname fallback to `basename($url)` for pre-v2.3.0 data). Anywhere a write or auth check fails, log nothing but surface a user-visible error.
+
+Canonical pattern — see the merge AJAX handler at `simple-wp-helpdesk.php:183-199`:
+
+```php
+function swh_ajax_merge_ticket() {
+    check_ajax_referer( 'swh_merge_ticket', 'nonce' );
+    if ( ! current_user_can( 'manage_options' ) ) {
+        wp_send_json_error( array( 'message' => __( 'Permission denied.', 'simple-wp-helpdesk' ) ), 403 );
+    }
+    $source_id = isset( $_POST['source_id'] ) && is_scalar( $_POST['source_id'] ) ? absint( $_POST['source_id'] ) : 0;
+    $target_id = isset( $_POST['target_id'] ) && is_scalar( $_POST['target_id'] ) ? absint( $_POST['target_id'] ) : 0;
+    if ( ! $source_id || ! $target_id || $source_id === $target_id ) {
+        wp_send_json_error( array( 'message' => __( 'Invalid ticket IDs.', 'simple-wp-helpdesk' ) ) );
+    }
+    if ( ! swh_merge_tickets( $source_id, $target_id ) ) {
+        wp_send_json_error( array( 'message' => __( 'Merge failed. Check that both tickets exist.', 'simple-wp-helpdesk' ) ) );
+    }
+    wp_send_json_success( array( 'message' => __( 'Tickets merged successfully.', 'simple-wp-helpdesk' ) ) );
+}
+```
+
+Nonce → capability → input sanitization → input validation → action → JSON response. In that order.
+
+## Comments policy
+
+Comment the **WHY**, not the **WHAT**. Reading well-named code already tells the reader what it does; a comment that paraphrases the code is noise.
+
+Comment is required when:
+- A piece of code exists to work around a specific WP behaviour, host quirk, or upstream bug. Include the version or reproduction step.
+- A `phpcs:ignore` or `nosemgrep:` is being added — the comment justifies why it is safe.
+- A non-obvious invariant is being preserved. The canonical example is the docblock on `swh_set_ticket_status()` at `helpers.php:144-163` — it explains why initial-create callers must call `update_post_meta()` directly rather than going through the helper.
+
+Comment is **not** wanted when:
+- Restating the function name (`// Get the user IP` above `$ip = swh_get_client_ip();`).
+- Describing trivially obvious branching (`// if empty, return`).
+- Explaining what a well-named WP function does.
+
+Docblocks on public functions are mandatory and PHPCS-enforced; they document parameters, return type, and `@since`.
+
+## i18n
+
+- Wrap every user-facing string with `__()`, `_e()`, `esc_html__()`, or `esc_html_e()`.
+- Text domain is `'simple-wp-helpdesk'` everywhere.
+- **Do not** wrap admin-editable default values (the defaults in `swh_get_defaults()` at `helpers.php:22-118`). They are stored verbatim in `wp_options`, and translators have no way to translate an option that the operator can edit. They become the operator's content the moment the plugin activates.
+- Use `printf` / `sprintf` with `%s` / `%d` for substitutions, and include a `/* translators: */` comment when the substitution is non-obvious. See examples at `simple-wp-helpdesk.php:111, 117, 125`.
+
+## JS conventions
+
+See `js-architecture.md`. In short:
+
+- Vanilla JS, built via `@wordpress/scripts` to `assets/dist/`.
+- One IIFE per module; no global mutation other than a documented `window.swh*` namespace (e.g. `window.swhToast`).
+- Asset manifests (`*.asset.php`) drive `wp_enqueue_script` version + deps — see `swh_enqueue_toast_script()` at `helpers.php:864-891`.
+
+## PR-time gates
+
+These are non-negotiable. The pre-push hook enforces #1; reviewers enforce the rest.
+
+1. **`make test-docker` passes locally before push.** No `--no-verify`. No host-PHP fallback.
+2. **Schema-ish change?** If you added, renamed, or removed any option / post meta / comment meta / transient / capability / CPT / taxonomy — update `data-dictionary.md` in the same PR.
+3. **Setting change?** If you added, changed the default of, or removed any item in `swh_get_defaults()` — update `config-reference.md` in the same PR.
+4. **Public API change?** If you added, changed the signature of, or removed any `do_action('swh_*')`, `apply_filters('swh_*')`, REST endpoint, AJAX endpoint, or shortcode attribute — update `api-contract.md` and `docs/developer/hooks.md` in the same PR. See `api-contract.md` for the SemVer breaking-change taxonomy.
+5. **Security posture change?** If you added a new untrusted input source, a new auth flow, a new file or URL handling path — update `security-model.md` in the same PR.
+6. **New UI primitive or design token?** Update `component-inventory.md` in the same PR.
+7. **User-facing feature or regression?** A new or extended Playwright section in `testing/scripts/test_helpdesk_pw.py` ships in the same PR. See `testing-guide.md` for the test update policy.
+8. **Operator-visible change?** Update `docs/` (user-facing) and `CHANGELOG.md` in the same PR.
+
+## Update protocol
+
+Update this doc when:
+- A new sanitization/escaping function becomes a standard pattern in the codebase.
+- A new PR-time gate is added or an existing one is dropped.
+- The PHP / WP version floor changes.
+- A naming convention is added (new prefix, new namespace).
+- The "canonical pattern" example becomes stale because a better one lands.

--- a/docs/internal/config-reference.md
+++ b/docs/internal/config-reference.md
@@ -87,7 +87,7 @@ These belong to the **Tools** form (separate nonce — see `design-document.md` 
 
 ### Email Templates
 
-14 subject/body pairs. Templates support `{placeholder}` substitution and `{if key}…{endif key}` conditional blocks (see `swh_parse_template` filter).
+16 subject/body pairs. Templates support `{placeholder}` substitution and `{if key}…{endif key}` conditional blocks (see `swh_parse_template` filter).
 
 | Option key | Default | Purpose |
 |---|---|---|

--- a/docs/internal/config-reference.md
+++ b/docs/internal/config-reference.md
@@ -1,0 +1,194 @@
+# Configuration Reference
+
+**Audience:** operators and contributors.
+
+## Source of truth
+
+`swh_get_defaults()` at `simple-wp-helpdesk/includes/helpers.php:19-121`. This document reflects that function. **If they disagree, the function wins** — fix the doc.
+
+Options are seeded on first admin page load (`add_option()` loop at `class-installer.php:112-114`). The static cache in `swh_get_defaults()` makes per-request reads cheap.
+
+## Reading options correctly
+
+Use `swh_get_option( $group, $key, $default )` (defined at `helpers.php:139-142`):
+
+```php
+$autoclose_days = swh_get_option( 'general', 'autoclose_days', 3 );
+$assignee       = swh_get_option( 'routing', 'default_assignee' );
+$rules          = swh_get_option( 'routing', 'assignment_rules', array() );
+```
+
+The `$key` argument is the option name **without** the `swh_` prefix. The `$group` is advisory in v3.7 (intentionally ignored — see invariant in `api-contract.md`); v4.0 (#356) will consume it for the schema split, so always pass the correct group at call time.
+
+For typed reads use `swh_get_string_option()` / `swh_get_int_option()` (`helpers.php:494-509`) — both wrap `get_option()` with a `is_scalar` guard for PHPStan L9 compliance.
+
+## Settings groups (v3.7+ taxonomy)
+
+The group argument is one of: `general`, `email`, `portal`, `notifications`, `tools`, `routing`, `integrations`. The same option can belong to multiple groups conceptually — pass the group that matches the caller's context.
+
+### General
+
+| Option key | Default | Type | Admin UI tab | Purpose |
+|---|---|---|---|---|
+| `swh_ticket_priorities` | `Low, Medium, High` | comma-string | General | Comma-separated priority labels. Filter: `swh_ticket_priorities`. |
+| `swh_default_priority` | `Medium` | string | General | Default priority for new tickets. |
+| `swh_ticket_statuses` | `Open, In Progress, Resolved, Closed` | comma-string | General | Comma-separated status labels. Filter: `swh_ticket_statuses`. |
+| `swh_default_status` | `Open` | string | General | Default status on new submission. |
+| `swh_resolved_status` | `Resolved` | string | General | Status considered "resolved" — used by the auto-close cron. |
+| `swh_closed_status` | `Closed` | string | General | Status considered "closed" — used by status transition logic. |
+| `swh_reopened_status` | `Open` | string | General | Status set when a client reopens a closed ticket. |
+| `swh_autoclose_days` | `3` | int | General | Days a `Resolved` ticket waits before auto-close. Filter: `swh_autoclose_threshold`. |
+| `swh_max_upload_size` | `5` | int (MB) | General | Per-file upload size limit. |
+| `swh_max_upload_count` | `5` | int | General | Per-submission upload count limit. |
+
+### Assignment & Routing
+
+| Option key | Default | Type | Admin UI tab | Purpose |
+|---|---|---|---|---|
+| `swh_default_assignee` | `''` | int (user id) or empty | Assignment & Routing | Fallback assignee when no rule matches. |
+| `swh_fallback_email` | `''` | string (email) | Assignment & Routing | Email address that receives admin notifications when no assignee is set. |
+| `swh_ticket_page_id` | `0` | int (post id) | Assignment & Routing | Page hosting `[helpdesk_portal]`. `0` falls back to `_ticket_url` post meta. |
+| `swh_token_expiration_days` | `90` | int | Assignment & Routing | Portal token TTL in days. `0` disables expiration. |
+| `swh_restrict_to_assigned` | `no` | `yes`/`no` | Assignment & Routing | Technicians see only assigned tickets in admin list and via `load-post.php`. See invariant #13. |
+| `swh_assignment_rules` | `[]` | array of `{category_term_id, assignee_user_id}` | Assignment & Routing | First matching rule wins; falls back to `swh_default_assignee`. |
+
+### Email Format
+
+| Option key | Default | Type | Admin UI tab | Purpose |
+|---|---|---|---|---|
+| `swh_email_format` | `html` | `html`/`plain` | Email Templates | Send HTML-wrapped or plain emails. |
+| `swh_email_logo_url` | `''` | string (URL) | Email Templates | Logo shown in the HTML email header. Falls back to `get_site_icon_url(48)`. |
+
+### Anti-Spam
+
+| Option key | Default | Type | Admin UI tab | Purpose |
+|---|---|---|---|---|
+| `swh_spam_method` | `honeypot` | `honeypot`/`recaptcha`/`turnstile` | Anti-Spam | Active anti-spam method. |
+| `swh_recaptcha_site_key` | `''` | string | Anti-Spam | Site key. |
+| `swh_recaptcha_secret_key` | `''` | string | Anti-Spam | Secret (v2 / v3). |
+| `swh_recaptcha_type` | `v2` | `v2`/`enterprise` | Anti-Spam | reCAPTCHA flavor. |
+| `swh_recaptcha_project_id` | `''` | string | Anti-Spam | Enterprise project ID. |
+| `swh_recaptcha_api_key` | `''` | string | Anti-Spam | Enterprise API key. |
+| `swh_recaptcha_threshold` | `0.5` | float-as-string | Anti-Spam | Enterprise score threshold (0.0 to 1.0). |
+| `swh_turnstile_site_key` | `''` | string | Anti-Spam | Cloudflare Turnstile site key. |
+| `swh_turnstile_secret_key` | `''` | string | Anti-Spam | Cloudflare Turnstile secret. |
+
+Misconfigured credentials fail **closed** — see `security-model.md`.
+
+### Data Retention & Tools
+
+These belong to the **Tools** form (separate nonce — see `design-document.md` invariant #9).
+
+| Option key | Default | Type | Admin UI tab | Purpose |
+|---|---|---|---|---|
+| `swh_retention_attachments_days` | `0` | int | Tools | Attachment retention window. `0` disables. |
+| `swh_retention_tickets_days` | `0` | int | Tools | Ticket retention window. `0` disables. |
+| `swh_delete_on_uninstall` | `no` | `yes`/`no` | Tools | When `yes`, uninstall wipes all options, posts, files, and the Technician role. |
+
+### Email Templates
+
+14 subject/body pairs. Templates support `{placeholder}` substitution and `{if key}…{endif key}` conditional blocks (see `swh_parse_template` filter).
+
+| Option key | Default | Purpose |
+|---|---|---|
+| `swh_em_user_new_sub` / `_body` | (see `swh_get_defaults()`) | Sent to the client on new ticket creation. |
+| `swh_em_user_reply_sub` / `_body` | … | Sent to client when staff replies. |
+| `swh_em_user_status_sub` / `_body` | … | Sent to client on status-only change. |
+| `swh_em_user_reply_status_sub` / `_body` | … | Sent to client on combined reply + status change. |
+| `swh_em_user_resolved_sub` / `_body` | … | Sent to client when ticket is marked resolved. |
+| `swh_em_user_reopen_sub` / `_body` | … | Sent to client when ticket is reopened. |
+| `swh_em_user_autoclose_sub` / `_body` | … | Sent to client on auto-close. |
+| `swh_em_user_closed_sub` / `_body` | … | Sent to client when they close their own ticket via the portal. |
+| `swh_em_admin_new_sub` / `_body` | … | Sent to admin/assignee on new ticket. |
+| `swh_em_admin_reply_sub` / `_body` | … | Sent to admin/assignee on client reply. |
+| `swh_em_admin_reopen_sub` / `_body` | … | Sent to admin/assignee on client reopen. |
+| `swh_em_admin_closed_sub` / `_body` | … | Sent to admin/assignee when client closes. |
+| `swh_em_assigned_sub` / `_body` | … | Sent to the new assignee on assignment change. |
+| `swh_em_user_lookup_sub` / `_body` | … | Sent in response to the lookup form (open tickets list). |
+| `swh_em_admin_sla_breach_sub` / `_body` | … | Digest sent when SLA cron finds breaches. |
+| `swh_em_user_merged_sub` / `_body` | … | Sent to source-ticket client when their ticket is merged into a target. |
+
+**These defaults are operator-editable content and are intentionally not translated** — see `coding-guide.md` "i18n".
+
+### Messages (client-facing strings)
+
+| Option key | Default | Purpose |
+|---|---|---|
+| `swh_msg_success_new` | `Your ticket has been submitted successfully! …` | After new submission. |
+| `swh_msg_success_reply` | `Your reply has been added.` | After portal reply. |
+| `swh_msg_success_reopen` | `Your ticket has been successfully re-opened. …` | After portal reopen. |
+| `swh_msg_success_closed` | `Your ticket has been successfully closed.` | After portal close. |
+| `swh_msg_err_spam` | `Anti-spam verification failed. Please try again.` | When `swh_check_antispam()` rejects. |
+| `swh_msg_err_missing` | `Please fill in all required fields.` | When required fields are missing. |
+| `swh_msg_err_invalid` | `Invalid or expired ticket link.` | When token compare fails. |
+| `swh_msg_err_expired` | `This ticket link has expired. …` | When `swh_is_token_expired()` returns true. |
+| `swh_msg_success_lookup` | `If we have tickets on file for that email …` | Lookup form (deliberately ambiguous — no email enumeration). |
+
+### Canned Responses / Templates
+
+| Option key | Default | Type | Purpose |
+|---|---|---|---|
+| `swh_canned_responses` | `[]` | array | Saved reply templates available in the ticket editor. |
+| `swh_ticket_templates` | `[]` | array | Pre-configured submission types with pre-filled descriptions. |
+
+### SLA
+
+| Option key | Default | Type | Purpose |
+|---|---|---|---|
+| `swh_sla_warn_hours` | `4` | string (numeric) | Warn threshold in hours. |
+| `swh_sla_breach_hours` | `8` | string (numeric) | Breach threshold in hours. |
+| `swh_sla_notify_email` | `''` | string (email) | Recipient of the SLA breach digest. |
+
+### Integrations
+
+| Option key | Default | Type | Purpose |
+|---|---|---|---|
+| `swh_inbound_secret` | `''` | string | Bearer token required by the inbound-email REST endpoint. Empty disables the endpoint (every call fails auth). |
+
+### Frontend Portal Appearance
+
+| Option key | Default | Type | Purpose |
+|---|---|---|---|
+| `swh_portal_theme` | `auto` | `auto`/`light` | `auto` follows `prefers-color-scheme`; `light` forces light mode via `data-swh-theme="light"` on `.swh-helpdesk-wrapper`. |
+
+## Excluded from defaults but managed
+
+| Option | Source of truth |
+|---|---|
+| `swh_db_version` | `class-installer.php:147`. Used by `swh_run_upgrade_routine()` to gate upgrade work. Not in `swh_get_all_option_keys()`. |
+| `swh_comment_type_v2` | One-time migration flag (set at `class-installer.php:104`; deleted at uninstall). |
+| `swh_tech_caps_v2` | One-time migration flag (set at `class-installer.php:176`; deleted at uninstall). |
+| `swh_rl_<hash>` | Rate-limit locks. Bulk-deleted by `LIKE 'swh\_rl\_%'` at uninstall (`class-installer.php:228`). |
+
+## Override pattern (wp-config constants)
+
+`grep -nE "defined\(\s*'SWH_" simple-wp-helpdesk/` reveals only the bootstrap constants (`SWH_VERSION`, `SWH_PLUGIN_DIR`, `SWH_PLUGIN_URL`, `SWH_PLUGIN_FILE`, and the icon URL constants). **No setting can currently be overridden via `wp-config.php` constants.** All options are admin-UI only. If constant overrides are added (e.g. for the inbound secret), document them here and treat the change as MINOR.
+
+## Adding a new option
+
+1. Add the key with its default to `swh_get_defaults()` at `simple-wp-helpdesk/includes/helpers.php`.
+2. Pick the correct group (`general`, `email`, `portal`, `notifications`, `tools`, `routing`, `integrations`). The group is advisory in v3.7 but consumed in v4.0.
+3. Render and persist the field in the matching tab of `admin/class-settings.php`. If it is destructive, put it on the **Tools** form (separate nonce).
+4. If a write path other than the settings form touches it, document that path in the PR.
+5. Update this doc. Update `data-dictionary.md` if the new option is structured (array / JSON).
+6. Add a Playwright section under `testing-guide.md` if the option has user-visible effect.
+
+## Removed options
+
+None recorded in the v3.x line. When an option is removed:
+
+- Document it here with: removed in version, reason, migration notes.
+- Add a `delete_option()` in `swh_run_upgrade_routine()`.
+- Bump MAJOR per `api-contract.md`.
+
+| Option | Removed in | Reason | Migration |
+|---|---|---|---|
+| _none yet_ | | | |
+
+## Update protocol
+
+Update this doc when:
+- An option is added, removed, or has its default changed in `swh_get_defaults()` — keep in lock-step.
+- A new settings group is introduced.
+- A constant-override path is added.
+- A migration removes or renames an option — record it in the "Removed options" table.

--- a/docs/internal/config-reference.md
+++ b/docs/internal/config-reference.md
@@ -1,6 +1,8 @@
 # Configuration Reference
 
-**Audience:** operators and contributors.
+**Audience:** internal contributors and AI agents.
+
+> Operators: see `docs/configuration.md` and the rest of `docs/*.md` for end-user / site-admin guidance. This page is the developer-facing reference that mirrors `swh_get_defaults()` in code.
 
 ## Source of truth
 

--- a/docs/internal/data-dictionary.md
+++ b/docs/internal/data-dictionary.md
@@ -1,0 +1,151 @@
+# Data Dictionary
+
+**Audience:** plugin contributors, data-protection / audit reviewers.
+
+Every persistent piece of state the plugin owns. If a key is not in this doc and not owned by WordPress core, it does not exist.
+
+## Storage map overview
+
+The plugin uses **no custom database tables**. State lives in standard WordPress storage:
+
+| Concept | Storage primitive | Table |
+|---|---|---|
+| Ticket | CPT (`helpdesk_ticket`) | `wp_posts` |
+| Reply / internal note | Comment (`comment_type = 'helpdesk_reply'`) | `wp_comments` |
+| Ticket field | Post meta | `wp_postmeta` |
+| Reply field | Comment meta | `wp_commentmeta` |
+| Plugin setting | Option | `wp_options` (autoloaded by default) |
+| Cache / lock | Transient | `wp_options` (or object cache if available) |
+| Rate-limit lock | Option `swh_rl_<hash>` (NOT a transient — survives cache flush) | `wp_options` |
+| Category | Taxonomy term | `wp_terms`, `wp_term_taxonomy`, `wp_term_relationships` |
+| Capability | Role (added at activation, removed at uninstall) | `wp_options` (`wp_user_roles`) |
+
+See `design-document.md` invariant #1 for the rationale.
+
+## Post meta keys
+
+Cited from `grep -rEon "(update|get|delete)_post_meta\(...\)"` on `simple-wp-helpdesk/`. All keys begin with `_` (hidden meta).
+
+| Key | Type | Required? | Purpose | Since |
+|---|---|---|---|---|
+| `_ticket_status` | string | yes | Current status label (free string matching one of the configured statuses). Written only via `swh_set_ticket_status()` except for initial-create. | 1.0 |
+| `_ticket_priority` | string | yes | Priority label from `swh_get_priorities()`. | 1.0 |
+| `_ticket_name` | string | yes | Client display name from submission. | 1.0 |
+| `_ticket_email` | string | yes | Client email address. Compared to inbound webhook sender. Compared to `wp_get_current_user()->user_email` for My Tickets. | 1.0 |
+| `_ticket_token` | string | yes | Random token for portal access. Compared with `hash_equals`. | 1.0 |
+| `_ticket_token_created` | int (unix ts) | no (grandfathered) | When the token was generated. Absence on a pre-v1.9.0 ticket means "never expire". | 1.9.0 |
+| `_ticket_url` | string | optional | Stored permalink of the submission page; fallback for `swh_get_secure_ticket_link()` when `swh_ticket_page_id` is unset. | 1.0 |
+| `_ticket_uid` | string | yes | Human-readable ticket UID (`TKT-XXXX`). Used in subjects, merge breadcrumbs, inbound webhook subject parsing. | 1.0 |
+| `_ticket_assigned_to` | int (user id) | no | Assignee user ID. `0` = unassigned. Set by `swh_apply_assignment_rules()` or manual admin edit. | 1.0 |
+| `_ticket_attachments` | string[] (URLs) | no | URLs of root-level attachments (uploaded with the new ticket). | 1.0 |
+| `_ticket_attachment_url` | string | legacy | Pre-v2 single-attachment field. Still referenced for migration. | 1.0 |
+| `_ticket_attachment_id` | int | legacy | Pre-v2 single-attachment field. | 1.0 |
+| `_swh_attachment_orignames` | array<string,string> | optional | Map of attachment URL → original filename for new-ticket uploads. Falls back to `basename($url)` if missing (pre-v2.3.0). | 2.3.0 |
+| `_resolved_timestamp` | int (unix ts) | optional | Set when ticket transitions to the resolved status; used by the auto-close cron to detect tickets eligible for auto-close. | 1.0 |
+| `_ticket_first_response_at` | int (unix ts) | optional | Unix timestamp of the first staff reply. Used by first-response-time reporting. | 3.0.0 |
+| `_ticket_sla_status` | string (`warn`/`breach`) | optional | Latest SLA evaluation; set by `swh_sla_check_event`. | 3.0.0 |
+| `_ticket_cc_emails` | string (comma-sep) | optional | Comma-separated CC/watcher addresses. Read via `swh_get_cc_emails()` which sanitizes and validates. | 3.0.0 |
+| `_ticket_template` | string | optional | Label of the ticket template selected at submission. | 3.0.0 |
+| `_ticket_csat` | int (1–5) | optional | Client satisfaction rating; not set if the client dismisses the prompt. Written by the `swh_submit_csat` AJAX handler. | 3.0.0 |
+| `_swh_unread` | string (`'1'`) | optional | Set to `'1'` when a client posts a reply; cleared when admin opens the ticket. Pairs with the `swh_unread_count` transient (see invariant #17). | 3.1.0 |
+| `_edit_lock` | string | WP core | WordPress's own concurrent-edit lock. Not owned by this plugin. | WP core |
+
+## Comment meta keys
+
+Comments carry these meta when `comment_type='helpdesk_reply'`:
+
+| Key | Type | Required? | Purpose | Since |
+|---|---|---|---|---|
+| `_is_internal_note` | string (`'1'`) | optional | Staff-only note. **Must be filtered out** of any frontend renderer. | 2.0.0 |
+| `_is_user_reply` | string (`'1'`) | optional | Marks a portal-side or inbound-email reply (i.e. came from the client, not staff). Used by reporting to attribute first-response time correctly. | 2.0.0 |
+| `_swh_reply_orignames` | array<string,string> | optional | Per-comment map of attachment URL → original filename for replies and reopens. Falls back to `basename($url)` if missing. | 2.3.0 |
+| `_attachments` | string[] (URLs) | optional | Attachment URLs on the reply comment. | 1.0 |
+
+## Options
+
+Enumerated in `simple-wp-helpdesk/includes/helpers.php:19-121` (`swh_get_defaults()`). See `config-reference.md` for the exhaustive list with defaults, types, and admin UI location.
+
+Categories:
+
+- **General:** statuses, priorities, autoclose, max upload.
+- **Assignment & Routing:** default assignee, fallback email, helpdesk page, token TTL, technician restriction.
+- **Email Format:** format, logo URL.
+- **Anti-Spam:** method, reCAPTCHA keys/type, Turnstile keys.
+- **Data Retention & Tools:** retention windows, delete-on-uninstall.
+- **Email Templates:** 14 subject/body pairs (see `config-reference.md`).
+- **Messages:** success/error strings shown to clients.
+- **Canned Responses:** structured array.
+- **Ticket Templates:** structured array.
+- **SLA:** warn/breach hours, notify email.
+- **Assignment Rules:** JSON array of `{category_term_id, assignee_user_id}`.
+- **Inbound Email:** Bearer secret.
+- **Frontend Portal Appearance:** theme preference.
+
+Additionally:
+
+- `swh_db_version` — installed plugin version; updated by `swh_run_upgrade_routine()` at `class-installer.php:147`. **Not** in `swh_get_defaults()` and **excluded** from bulk operations (`swh_get_all_option_keys()` filters it out).
+- `swh_comment_type_v2`, `swh_tech_caps_v2` — one-time migration flags. Cleaned on uninstall.
+
+## Transients
+
+| Key | TTL | Purpose | Set by | Cleared by |
+|---|---|---|---|---|
+| `swh_unread_count` | 5 min | Cached count of tickets with `_swh_unread=1`. | `swh_get_unread_reply_count()` at `helpers.php:740-764`. | Any write to `_swh_unread` (see invariant #17). |
+| `swh_report_avg_resolution_time` | `HOUR_IN_SECONDS` | Reporting cache. | `admin/class-reporting.php`. | Hourly expiration. |
+| `swh_report_first_response_time` | `HOUR_IN_SECONDS` | Reporting cache. | `admin/class-reporting.php`. | Hourly expiration. |
+| `swh_report_<other types>` | `HOUR_IN_SECONDS` | Reporting cache for `status_breakdown`, `weekly_trend`, `kpi`. | `admin/class-reporting.php`. | Hourly expiration. |
+| `swh_lock_clear_<post_id>` | 3 min | Suppresses unread-row highlight after admin opens a ticket. | `admin/class-ticket-editor.php:455`. | 3-minute expiration. |
+| `swh_lock_autoclose` | cron-duration | Single-instance lock for the auto-close cron. | `class-cron.php:56`. | Cron handler on exit. |
+| `swh_lock_retention_att` | cron-duration | Lock for the attachment-retention cron. | `class-cron.php:145`. | Cron handler on exit. |
+| `swh_lock_retention_tkt` | cron-duration | Lock for the ticket-retention cron. | `class-cron.php:280`. | Cron handler on exit. |
+| `swh_lock_sla` | cron-duration | Lock for the SLA-check cron. | `class-cron.php:330`. | Cron handler on exit. |
+
+**`swh_rl_*` are NOT transients** — they are stored as options with a TTL field embedded in the value. This is intentional: transients are flushed by aggressive object-cache resets that some hosts run. See `swh_is_rate_limited()` at `helpers.php:777-794`.
+
+## Taxonomy
+
+| Slug | Type | REST | Rewrite | Show admin column | Registered at |
+|---|---|---|---|---|---|
+| `helpdesk_category` | hierarchical | no (`show_in_rest=false`) | no (`rewrite=false`) | yes | `class-installer.php:311-338` |
+
+Assign with `wp_set_post_terms( $ticket_id, $term_ids, 'helpdesk_category' )`. Read with `wp_get_post_terms( $ticket_id, 'helpdesk_category', $args )`. Used by `swh_apply_assignment_rules()` to look up routing rules.
+
+## Capabilities
+
+| Capability | Granted to roles | Controls |
+|---|---|---|
+| `read` | Technician (added at activation) | basic WP login |
+| `edit_posts` | Technician | base post editing |
+| `edit_others_posts` | Technician | edit tickets created by others |
+| `edit_published_posts` | Technician | edit tickets after publish (all of them; v1.0 status was a meta field, not post_status) |
+| `publish_posts` | Technician | publish tickets |
+| `delete_posts` | Technician | delete tickets (admin UI) |
+| `upload_files` | Technician | attach files to replies |
+
+The `Technician` role is created at `class-activate()` and removed at `class-uninstall()` (see `class-installer.php:18-41, 234-239`). Existing users in the role are reassigned to the site's default role (`get_option('default_role', 'subscriber')`) before role removal.
+
+`manage_options` (WordPress core) gates all admin / settings / merge / test-email / reporting actions.
+
+## Migration policy
+
+- Meta keys are **load-bearing** and follow the same versioning as code (see `api-contract.md`).
+- **Adding** a new meta key is MINOR. Document it here in the same PR.
+- **Renaming** or **removing** a meta key is MAJOR. The change ships with an upgrade routine in `swh_run_upgrade_routine()` at `class-installer.php:87-148` that migrates old → new for existing installs.
+- **Adding** a comment meta is MINOR.
+- **Adding** an option is MINOR. **Adding** to `swh_get_defaults()` causes `add_option()` to seed it on next admin page load (line 113).
+- **Removing** an option is MAJOR. Add a `delete_option()` in the upgrade routine.
+
+## What is intentionally NOT here
+
+- **No custom tables.** See `design-document.md` invariant #1.
+- **No foreign keys.** WordPress does not enforce them.
+- **No application-managed sequences.** Use `wp_insert_post()`.
+- **No `register_post_meta()`.** Showing meta in REST is gated separately and not desired for these keys.
+- **No JSON columns.** Where structured data is needed (assignment rules, canned responses, ticket templates, attachment origname maps) it is stored as a serialised PHP array via WP's standard option/meta serialization. Read/write is via `get_*` / `update_*` only — never raw `unserialize()` on the raw column value.
+
+## Update protocol
+
+Update this doc when:
+- A new post meta, comment meta, option, transient, capability, or taxonomy term is added — bump the relevant table.
+- An existing key is renamed or removed — strike the old row, note the migration version, document the upgrade routine that converts existing data.
+- The migration policy itself is amended.

--- a/docs/internal/design-document.md
+++ b/docs/internal/design-document.md
@@ -1,0 +1,184 @@
+# Design Document
+
+**Audience:** plugin contributors, AI coding agents.
+
+## Architecture overview
+
+Simple WP Helpdesk is a WordPress plugin that delivers a complete ticketing/helpdesk system **without introducing any custom database tables**. All persistent state is stored in WordPress core primitives:
+
+- **Tickets** are posts of the custom post type `helpdesk_ticket` (`simple-wp-helpdesk/includes/class-installer.php:275`).
+- **Replies and internal notes** are comments with `comment_type = 'helpdesk_reply'` (set in `simple-wp-helpdesk/includes/helpers.php` via merge logic and elsewhere in the codebase).
+- **Ticket fields** (status, priority, assignee, token, etc.) are post meta keyed by `_ticket_*` and `_swh_*`.
+- **Plugin settings** are options under the `swh_*` prefix (see `swh_get_defaults()` at `simple-wp-helpdesk/includes/helpers.php:19-121`).
+- **Categories** are a custom taxonomy `helpdesk_category` (`class-installer.php:312`).
+
+The result is a plugin that installs without schema changes, uninstalls cleanly via standard WP option/post/comment deletion, and ports between hosts via any WP-native export/import path.
+
+The repository contains two distinct layers:
+
+- **Repository root** — dev tooling, CI, tests, Docker stack, documentation, packaging scripts. Nothing here ships to end users.
+- **`simple-wp-helpdesk/` subdirectory** — the actual plugin. This is what `release.yml` zips for distribution.
+
+## Repository layout
+
+```
+simple-wp-helpdesk/                     # repo root (dev tooling)
+├── simple-wp-helpdesk/                 # plugin root (shipped artifact)
+│   ├── simple-wp-helpdesk.php          # Bootstrap: constants, requires, lifecycle, AJAX/REST registration
+│   ├── includes/
+│   │   ├── helpers.php                 # Defaults, statuses, anti-spam, rate limiting, status transitions
+│   │   ├── class-installer.php         # Activation, deactivation, uninstall, upgrade, CPT, taxonomy
+│   │   ├── class-email.php             # Template parsing, send wrapper, HTML wrapper, inbound webhook
+│   │   ├── class-ticket.php            # File proxy, uploads, deletion, comment filters, CSAT AJAX
+│   │   ├── class-cron.php              # Auto-close, retention, SLA breach detection
+│   │   └── deprecations.php            # Soft-deprecation shims for removed/renamed APIs
+│   ├── admin/                          # Loaded only when is_admin() is true
+│   │   ├── class-settings.php          # Tabbed settings UI + save handler
+│   │   ├── class-ticket-editor.php     # Meta boxes, save_post, conversation UI
+│   │   ├── class-ticket-list.php       # Columns, sorting, filters, admin styles
+│   │   ├── class-reporting.php         # Reporting AJAX endpoints
+│   │   ├── class-reporting-ui.php      # Reports submenu page + Chart.js
+│   │   └── class-plugin-action-links.php
+│   ├── frontend/
+│   │   ├── class-shortcode.php         # [submit_ticket] + [helpdesk_portal] shortcodes
+│   │   └── class-portal.php            # Client portal view
+│   ├── vendor/                         # Composer + plugin-update-checker (bundled)
+│   ├── assets/                         # CSS, JS, icons. Built JS lands in assets/dist/
+│   ├── languages/                      # .pot / .po / .mo
+│   ├── src/                            # PSR-4 namespaced classes (v3.7+ PoC; additive)
+│   ├── composer.json                   # Runtime Composer manifest (autoload only)
+│   └── readme.txt                      # WordPress.org-style readme
+├── tests/Unit/                         # PHPUnit unit tests (WP_Mock)
+├── testing/                            # Playwright E2E + helpers
+├── docs/                               # User-facing + developer-facing + internal docs
+├── docker/, docker-compose.test.yml    # Local Docker test stack (WP + MySQL + MailHog)
+├── .github/workflows/                  # CI: php-tests, e2e, semgrep, coverage, release, claude
+├── Makefile                            # test-docker, e2e, e2e-docker, bench, js-build, etc.
+├── composer.json                       # Dev-time Composer (PHPCS, PHPStan, PHPUnit, WP_Mock)
+├── phpstan.neon, phpunit.xml, .phpcs.xml
+└── package.json                        # @wordpress/scripts JS build
+```
+
+Plugin-internal constants (defined in `simple-wp-helpdesk/simple-wp-helpdesk.php:19-27`):
+
+| Constant | Purpose |
+|---|---|
+| `SWH_VERSION` | Single source of truth for the version string (`3.7.0` at HEAD). |
+| `SWH_PLUGIN_DIR` | `plugin_dir_path(__FILE__)` of the bootstrap. Module files use this, never `__FILE__`. |
+| `SWH_PLUGIN_URL` | `plugin_dir_url(__FILE__)`. |
+| `SWH_PLUGIN_FILE` | The bootstrap path. Passed to `register_*_hook()` and `plugin_basename()`. |
+| `SWH_ICON_1X`, `SWH_ICON_2X`, `SWH_MENU_ICON` | Bundled brand assets — no CDN dependency. |
+
+## Module map
+
+| File | Responsibility |
+|---|---|
+| `simple-wp-helpdesk.php` | Bootstrap only. Defines constants, requires modules, registers lifecycle hooks (`register_activation_hook` etc.), configures plugin-update-checker, hosts the ticket-merge AJAX and REST inbound-email registration. |
+| `includes/helpers.php` | All `swh_*` global functions: defaults, options getters, status transitions, anti-spam, rate limiting, IP detection, portal link builder, merge, CC parsing, assignment rules, format helpers. |
+| `includes/class-installer.php` | Activation (Technician role + cron events), deactivation (cron cleanup), uninstall (full purge gated by `swh_delete_on_uninstall`), upgrade routine, CPT + taxonomy registration. |
+| `includes/class-email.php` | `swh_send_email()` template-driven mailer, `swh_wrap_html_email()` HTML wrapper with inlined CSS, inbound email REST callback. |
+| `includes/class-ticket.php` | File proxy `swh_serve_file()`, upload handling, ticket deletion (post + files), CSAT AJAX, comment list-table filters. |
+| `includes/class-cron.php` | Cron callbacks: auto-close, ticket retention, attachment retention, SLA check. Each guarded by a `swh_lock_*` transient. |
+| `includes/deprecations.php` | Soft-deprecation shims kept so old hook names still fire during a deprecation window. |
+| `admin/class-settings.php` | Tabbed settings page, render + save handler. Two distinct forms (main settings, Tools) with separate nonces. |
+| `admin/class-ticket-editor.php` | Meta boxes (status, priority, assignee), `save_post` handler, conversation rendering. |
+| `admin/class-ticket-list.php` | Admin list table customisation: columns, sorting, filters, badges. |
+| `admin/class-reporting.php` | `wp_ajax_swh_report_data` endpoint; caches via `swh_report_*` transients. |
+| `admin/class-reporting-ui.php` | Reports submenu render + Chart.js enqueue. |
+| `admin/class-plugin-action-links.php` | "Settings" link on the Plugins screen row. |
+| `frontend/class-shortcode.php` | `[submit_ticket]` and `[helpdesk_portal]` rendering and POST handling. |
+| `frontend/class-portal.php` | Token-authenticated portal: conversation view, reply, close/reopen, CSAT prompt. |
+
+## Load-bearing invariants
+
+If you violate one of these, something visible breaks. Cite line ranges before changing the surrounding code.
+
+| # | Invariant | What breaks if violated | Code location | Since |
+|---|---|---|---|---|
+| 1 | No custom database tables. Tickets, replies, fields, settings all live in WP core tables (`wp_posts`, `wp_comments`, `wp_postmeta`, `wp_commentmeta`, `wp_options`, `wp_term_*`). | Clean-install / clean-uninstall promise; backup/restore portability; the "zero-privilege" plugin install posture. | No `CREATE TABLE` exists anywhere — verified by absence in `class-installer.php`. | 1.0 |
+| 2 | All `wp_options` use the `swh_` prefix; all post meta use `_ticket_*` or `_swh_*`; all comment meta use `_is_*` / `_swh_*`. | Uninstall sweep relies on prefix `LIKE` queries (`class-installer.php:228-229`). Mis-prefixed keys persist forever. | `class-installer.php:228-244`; `helpers.php` getters. | 1.0 |
+| 3 | Status transitions go through `swh_set_ticket_status()`. It diffs old vs new, fires `swh_ticket_status_changed`, `swh_ticket_closed`, `swh_ticket_reopened`, and is a no-op when old equals new. **Initial-create** sites call `update_post_meta()` directly so `swh_ticket_created` is the single source of truth for creation. | Integrations subscribed to `swh_ticket_closed` miss events; double-fires on no-op writes; spurious "closed" events fire on initial create. | `helpers.php:164-213`. | 3.7.0 |
+| 4 | Reply comments are inserted with `comment_type = 'helpdesk_reply'`. The `swh_run_upgrade_routine()` v2 migration overwrites stale comment_type values to repair pre-v2 installs. Internal notes additionally carry `_is_internal_note = 1` comment meta and must be filtered out of frontend rendering. | Replies leak into the site's default comment templates; or staff-only notes leak to the client portal. | `helpers.php:668-684` (merge inserts); upgrade in `class-installer.php:92-105`. | 2.0.0 |
+| 5 | `_ticket_token` must be compared with `hash_equals()`, never `==`. Tokens missing `_ticket_token_created` are grandfathered (pre-v1.9.0) and never expire. | Timing oracle on token compare; or every pre-v1.9.0 ticket's portal link breaks the day expiration is enabled. | `helpers.php:336-346` (`swh_is_token_expired`); portal code uses `hash_equals`. | 1.9.0 |
+| 6 | Files are served only via `swh_serve_file()` (action `init` priority 1, `class-ticket.php:21`). The proxy validates the resolved path starts inside `wp_get_upload_dir()['basedir']`. Direct upload URLs in the browser must not be linkable to clients. | Authorization bypass / path traversal / unattenuated public reads of attached files. | `class-ticket.php:21-` (file proxy). | 2.0.0 |
+| 7 | `swh_get_client_ip()` is the only correct way to read the client IP. It honours `HTTP_CF_CONNECTING_IP` then `HTTP_X_FORWARDED_FOR` then `REMOTE_ADDR`. Never read `$_SERVER['REMOTE_ADDR']` directly. | Rate limiting and anti-spam misattribute when sitting behind a CDN or reverse proxy. | `helpers.php:356-365`. | 2.1.0 |
+| 8 | Email always goes through `swh_send_email( $to, $subject_key, $body_key, $data, $attachments, $ticket_id )`. It runs template parsing (`{placeholder}` + `{if key}…{endif key}`), applies the HTML wrapper, and dispatches `swh_email_headers` filter. Never call `wp_mail()` directly from feature code. | Skips branding wrapper; skips conditional-block parsing; bypasses the `swh_email_headers` filter; site-wide template overrides do not apply. | `class-email.php:90-` (send wrapper). | 1.0 |
+| 8.1 | The HTML wrapper inlines all CSS. No `<link>` and no `<style>` blocks are sent — webmail clients strip them. Email-client dark mode is opted into via `<meta name="color-scheme" content="light dark">` + an inline `@media (prefers-color-scheme: dark)` block (only Apple Mail / iOS Mail honour it). | Webmail clients render unstyled HTML. | `class-email.php:145-` (`swh_wrap_html_email`). | 3.6.0 |
+| 9 | Two distinct settings forms render on the settings page: the main form, and the **Tools** form. They use different nonces. Tools exclusively owns `swh_retention_*` and `swh_delete_on_uninstall`. Mixing fields across forms either silently drops the value or invokes the wrong handler. | Settings save silently no-ops; or destructive Tools options fire from the main form without the Tools nonce. | `admin/class-settings.php` render + save handlers. | 2.2.0 |
+| 10 | `swh_save_ticket_data()` in `admin/class-ticket-editor.php` is the only place admin-side ticket edits flow through. It detects changes and dispatches emails. Adding a new ticket field means: (a) add the meta to `data-dictionary.md`, (b) wire save here, (c) handle the change detection if it triggers email. | New ticket fields silently fail to persist or fail to notify. | `admin/class-ticket-editor.php` (`swh_save_ticket_data`). | 1.0 |
+| 11 | New cron events use **unique scheduled offsets** so they do not all fire at the same second. Current offsets at activation: `swh_autoclose_event` = now, `swh_retention_tickets_event` = now + 1800, `swh_retention_attachments_event` = now + 3600, `swh_sla_check_event` = now + 5400. Each callback is guarded by a `swh_lock_*` transient. | Concurrent execution thrashes WP option locks; one cron event blocks the others. | `class-installer.php:42-53`; locks at `class-cron.php:56, 145, 280, 330`. | 2.0.0 / 3.0.0 |
+| 12 | `pre_get_posts` with a `meta_key` argument implicitly filters out posts lacking that meta. Setting `meta_key` to drive ordering or filtering on the ticket list will silently hide tickets without that meta. Use `meta_query` with `NOT EXISTS` if you need to include nulls. | Admin list silently shows a subset of tickets. | Multiple `pre_get_posts` callers in `admin/class-ticket-list.php`. | 1.0 |
+| 13 | Technician restriction (`swh_restrict_to_assigned = yes`) is enforced **only** on the admin list-table query (`pre_get_posts`) and on direct `load-post.php`. Any custom `WP_Query` for `helpdesk_ticket` is **not** filtered. Reporting, AJAX, and any new query path must add the assignee filter explicitly. | Technician sees unassigned tickets via reporting or any new query. | `admin/class-ticket-list.php`; `admin/class-ticket-editor.php`. | 2.4.0 |
+| 14 | `swh_get_secure_ticket_link()` requires `_ticket_token` post meta to be present. **Order matters**: always `update_post_meta($id, '_ticket_token', $token)` before calling `swh_get_secure_ticket_link($id)`. If called first the function returns `false` and the email body falls back to a broken or wrong URL. | First confirmation email contains a broken link. | `helpers.php:308-325`. | 1.9.0 |
+| 15 | Portal rate-limit keys are **per-action**: `portal_close_`, `portal_reopen_`, `portal_reply_` + ticket id. Sharing a key across actions blocks immediate reopen after close. | Client cannot reopen a ticket they just closed (or vice versa). | `helpers.php:777-794`; portal handlers in `frontend/class-portal.php`. | 2.1.0 |
+| 16 | Original filenames live in **two** parallel locations: post meta `_swh_attachment_orignames` (new-ticket uploads, keyed by file URL), and comment meta `_swh_reply_orignames` (reply uploads — one meta entry per comment, keyed by file URL). Pre-v2.3.0 tickets have neither and must fall back to `basename($url)`. | Conversation UI shows hashed upload filenames instead of human-readable ones. | Merge code at `helpers.php:655-660`; ticket save handler. | 2.3.0 |
+| 17 | The `_swh_unread` post meta and the `swh_unread_count` 5-minute transient are paired. Whenever code sets or clears `_swh_unread` it MUST `delete_transient('swh_unread_count')`. | Admin unread badge displays a stale count for up to 5 minutes. | `helpers.php:740-764` (read); ticket-editor + portal handlers (write). | 3.1.0 |
+
+## Design decisions
+
+These are embedded rationale notes, not separate ADRs. Each decision answers a recurring "why is it like this?" question.
+
+### No custom DB tables
+
+The plugin promises "zero-privilege install, clean uninstall, WP-native portability". Custom tables would require `dbDelta()` migrations, separate backup/restore paths, and host-level CREATE privileges. Restricting ourselves to CPT + comments + meta + options keeps the install footprint identical to any other plugin, makes any WP backup tool a complete backup of the helpdesk, and reduces the uninstall surface to "delete all rows with our prefix". The trade-off is performance: meta-based filtering does not scale past tens of thousands of tickets. `performance-baseline.md` records the measured limits. Migration to indexed tables is parked for v4.x — see `release_v4.x.x_roadmap.md`.
+
+### Storage map: CPT vs comments vs meta vs options
+
+| Concept | Storage | Why not the other choices |
+|---|---|---|
+| Ticket | CPT (`helpdesk_ticket`) | Inherits WP's editor, auth model, list table, REST infrastructure. Alternative would be a custom table, rejected per above. |
+| Reply / internal note | Comment (`comment_type = 'helpdesk_reply'`) | Inherits WP's threading, moderation, author tracking. CPT-per-reply was rejected as it would explode the post count and break the editor screen. |
+| Ticket field (status, priority, etc.) | Post meta | Each ticket has 10+ fields; storing them as columns on a custom table was rejected per above. `register_post_meta` is intentionally not used because show-in-REST is gated separately. |
+| Plugin setting | Option | Settings are global, not per-post. The Settings API does not work with meta. |
+| Categorization | Taxonomy (`helpdesk_category`) | Hierarchical categories are exactly what custom taxonomies are for. Rolling our own would lose admin column rendering and term-query optimisation. |
+| Caching of expensive reads | Transient | TTL-based eviction is exactly what transients give us. Persistent option storage was rejected because it bloats `wp_options`. |
+| Rate-limit lock | Option (`swh_rl_*`, not a transient) | The lock value (an epoch timestamp) must survive `wp_cache_flush()` calls and object-cache flushes that some hosts run aggressively. Transients are cleared by these flushes; options are not. |
+
+### `swh_send_email()` is the only mail dispatcher
+
+Templates ship as 14 option pairs (`*_sub` / `*_body`), parsed with placeholder + `{if}/{endif}` substitution, then wrapped in an HTML shell with inlined CSS, then dispatched. Calling `wp_mail()` directly skips all three layers. The `swh_email_headers` filter (`class-email.php:109`) is the supported integration point.
+
+### PSR-4 additive coexistence with `require_once`
+
+v3.7.0 introduces a `src/` PSR-4 namespace (`SWH\…`) as a proof-of-concept while leaving the existing `require_once` calls intact. The autoloader (`vendor/autoload.php`) is required at bootstrap (`simple-wp-helpdesk.php:30-32`). Both styles coexist — new code can land in either form. Full migration is deferred to v4.x.
+
+### Two settings forms, two nonces
+
+The Tools tab houses the destructive options: data retention (which can delete tickets and attachments on a cron) and `delete_on_uninstall` (which permits full data nuke). Keeping these in a physically separate `<form>` with its own nonce prevents accidental save of one when the user thought they were saving the other, and gives PHPCS / Semgrep an easier time tracking the intent of each save handler.
+
+## Release engineering
+
+**Versioning:** SemVer (https://semver.org/). Versions are bumped in **three** places that must all match:
+
+1. `simple-wp-helpdesk/simple-wp-helpdesk.php` — `Version:` header (line 5) and `SWH_VERSION` constant (line 19).
+2. `simple-wp-helpdesk/readme.txt` — `Stable tag:` line.
+3. `CHANGELOG.md` — new entry at the top.
+
+`docs/` files for any changed behaviour are also updated in the same PR.
+
+**Build:** `.github/workflows/release.yml` triggers on any `v*.*.*` tag push and produces `simple-wp-helpdesk.zip` as a GitHub Release asset. **There is no manual zip step.**
+
+**Process:**
+
+1. Branch `release/vX.Y.Z` from `main`.
+2. Bump versions in the three places above and update `CHANGELOG.md`.
+3. Run `make test-docker` and `make e2e-docker` locally. Both must pass.
+4. Ask the user before opening a PR.
+5. Open PR to `main`. Close addressed GitHub issues from the PR.
+6. Run CodeRabbit review (`/review`). Address all actionable findings.
+7. Merge.
+8. Push the tag: `git tag vX.Y.Z && git push origin vX.Y.Z`.
+9. `release.yml` builds and publishes the GitHub Release automatically. Do not monitor; wait for user confirmation.
+
+**Auto-updater:** the plugin embeds `yahnis-elsts/plugin-update-checker` (`simple-wp-helpdesk/vendor/plugin-update-checker/`). It polls the GitHub releases of `seanmousseau/Simple-WP-Helpdesk` on the `main` branch and surfaces updates via the standard WP Dashboard → Updates UI.
+
+## Update protocol
+
+Update this doc when:
+- A new module is added under `simple-wp-helpdesk/{includes,admin,frontend}/`.
+- A new load-bearing invariant is introduced or an existing one is relaxed/removed.
+- The repository layout changes at the top-two levels.
+- The release engineering pipeline changes (new gate, new artifact, changed branch model).
+- A design decision is overturned — strike the old rationale, add the new one.
+
+Cite real file:line references for every claim. If you cannot cite, drop the claim.

--- a/docs/internal/design-document.md
+++ b/docs/internal/design-document.md
@@ -21,7 +21,7 @@ The repository contains two distinct layers:
 
 ## Repository layout
 
-```
+```text
 simple-wp-helpdesk/                     # repo root (dev tooling)
 ├── simple-wp-helpdesk/                 # plugin root (shipped artifact)
 │   ├── simple-wp-helpdesk.php          # Bootstrap: constants, requires, lifecycle, AJAX/REST registration

--- a/docs/internal/design-document.md
+++ b/docs/internal/design-document.md
@@ -136,7 +136,7 @@ The plugin promises "zero-privilege install, clean uninstall, WP-native portabil
 
 ### `swh_send_email()` is the only mail dispatcher
 
-Templates ship as 14 option pairs (`*_sub` / `*_body`), parsed with placeholder + `{if}/{endif}` substitution, then wrapped in an HTML shell with inlined CSS, then dispatched. Calling `wp_mail()` directly skips all three layers. The `swh_email_headers` filter (`class-email.php:109`) is the supported integration point.
+Templates ship as 16 option pairs (`*_sub` / `*_body`), parsed with placeholder + `{if}/{endif}` substitution, then wrapped in an HTML shell with inlined CSS, then dispatched. Calling `wp_mail()` directly skips all three layers. The `swh_email_headers` filter (`class-email.php:109`) is the supported integration point.
 
 ### PSR-4 additive coexistence with `require_once`
 

--- a/docs/internal/design-guide.md
+++ b/docs/internal/design-guide.md
@@ -1,0 +1,91 @@
+# Design Guide
+
+**Audience:** plugin contributors and designers.
+
+This doc covers the higher-level UX principles and when-to-use guidance. It defers component-level detail to existing authoritative docs:
+
+- **Primitives, CSS classes, design tokens** → `component-inventory.md`.
+- **JS module structure and build pipeline** → `js-architecture.md`.
+- **Performance budgets and measured baselines** → `performance-baseline.md`.
+
+If you came here looking for a class name or a token, you are in the wrong doc — read `component-inventory.md` instead.
+
+## UX principles
+
+### Frontend portal
+
+- **Auto-detect dark mode.** The `.swh-helpdesk-wrapper` root respects `prefers-color-scheme`. Sites that force a particular theme use the `data-swh-theme="light"` escape hatch on the wrapper.
+- **Accessible by default.** WCAG 2.2 AA is the floor. Specifically: focus-visible rings on every interactive element, a skip-to-content link, ARIA-live announcements for async feedback, focus management for the CSAT modal.
+- **Empty states are first-class.** Anywhere the user could see nothing, they see a labelled empty state (icon + title + description, optional CTA).
+- **Toast feedback for transient async outcomes.** Anything that resolves in under a few seconds and does not warrant a page change emits a toast.
+- **Form errors stay visible.** Validation messages are not removed by re-render; they remain until the user fixes the field.
+
+### Admin
+
+- **Opt-in dark mode.** Activated per-user via the WordPress admin colour scheme. `swh_admin_color_is_dark()` (`includes/helpers.php:839-850`) returns true for `midnight`, `modern`, `ectoplasm`. The selector `body.swh-helpdesk-admin.swh-admin-theme-dark` activates the token overrides in `swh-shared.css` and the component overrides in `swh-admin.css`.
+- **Admin lists are scannable.** Unread badges, priority colour chips, SLA warn/breach indicators surface at a glance without requiring the operator to open each row.
+- **Two settings forms.** Main vs Tools. Tools holds destructive options and uses its own nonce. Do not move fields across the boundary without considering invariant #9 in `design-document.md`.
+
+### Emails
+
+- **All CSS inlined.** No `<link>`, no `<style>` survives common webmail clients. Apple Mail / iOS Mail honour an inline `@media (prefers-color-scheme: dark)` block; that is the only dark-mode path supported.
+- **Logo at 32×32 in the header band.** Falls back to `get_site_icon_url(48)` if `swh_email_logo_url` is empty.
+- **`<meta name="color-scheme" content="light dark">`** opts emails into client dark mode.
+
+## Reusable patterns
+
+### Empty states
+
+Use the `.swh-empty-state` component whenever the user sees "nothing here". Required structure: `.swh-empty-state-icon` (inline SVG, `aria-hidden="true"`), `.swh-empty-state-title`, `.swh-empty-state-desc`. CTA link optional.
+
+For PHP-rendered empty states, prefer the helper `swh_render_empty_state( $title, $desc, $svg_path, $heading_level = 'h2' )` (`includes/helpers.php:811-828`). Pass the heading level appropriate to the surrounding hierarchy — admin lists usually want `h2`, sub-panels `h3`.
+
+### Toasts
+
+Use `.swh-toast` via `window.swhToast( msg, type )` for transient feedback (`success`, `error`, `info`). The JS is enqueued via `swh_enqueue_toast_script()` (`includes/helpers.php:864-891`), built by `@wordpress/scripts` to `assets/dist/toast.js` with a generated `toast.asset.php` manifest driving deps and cache-busting.
+
+### Panel groups
+
+The ticket editor sidebar uses `.swh-panel-group` + `.swh-panel-group-label` to organise Status / Priority / Assignee. Do **not** rename the input `id` attributes (`#swh-status`, `#swh-priority`, `#swh-assigned-to`) or the form field `name` attributes — the save handler depends on them.
+
+### Confirmation prompts
+
+Destructive admin actions use a JS-side confirm prompt before submission (e.g. delete ticket, run uninstall sweep). Never rely on browser native confirm for the primary flow — it is too easy to bypass with keyboard-only navigation. Use the toast + inline confirmation pattern documented in `component-inventory.md`.
+
+## Component inventory
+
+`component-inventory.md` is the source of truth for:
+
+- Primitive list (buttons, badges, cards, panels, empty states, toasts, etc.).
+- CSS class names and modifiers.
+- Token vocabulary (`--swh-color-*`, `--swh-space-*`, etc.).
+- Token appendix mapping light / dark values.
+
+When adding a new primitive or token, add it to `component-inventory.md` in the same PR. Cross-link from here only if a UX principle changes.
+
+## Token system
+
+See `component-inventory.md` "Tokens" appendix. The short version: design tokens are CSS custom properties scoped under `.swh-helpdesk-wrapper` (frontend) and `.swh-helpdesk-admin` (admin). Dark mode mutates the values; component CSS reads only token names, never raw colours.
+
+## JS architecture
+
+See `js-architecture.md`. The short version: vanilla JS, `@wordpress/scripts` build, one IIFE per module, `window.swh*` namespace for the public surface (currently only `window.swhToast`).
+
+## Dark mode reference
+
+| Surface | Activation | Selector | Defined in |
+|---|---|---|---|
+| Frontend portal | `prefers-color-scheme: dark` (auto) | `@media (prefers-color-scheme: dark)` in `swh-shared.css` | `swh-shared.css` |
+| Frontend portal escape | `swh_portal_theme=light` setting | `.swh-helpdesk-wrapper[data-swh-theme="light"]` | `swh-shared.css` |
+| Admin pages | per-user WP admin colour (`midnight`, `modern`, `ectoplasm`) | `body.swh-helpdesk-admin.swh-admin-theme-dark` | `swh-shared.css` (tokens) and `swh-admin.css` (components) |
+| Email | `<meta name="color-scheme">` + inline `@media (prefers-color-scheme: dark)` | inline in wrapper | `swh_wrap_html_email()` at `class-email.php:145` |
+
+## Update protocol
+
+Update this doc when:
+- A new high-level UX principle is added (e.g. a new accessibility commitment).
+- A new reusable pattern is named (the kind of thing that becomes a recurring shape across screens, not a one-off component).
+- A new top-level surface is added (e.g. an iframe widget, a block editor block).
+- The dark-mode wiring changes.
+
+For component-level changes, update `component-inventory.md`. For JS-level changes, update `js-architecture.md`. This doc holds the principles, not the inventory.

--- a/docs/internal/security-model.md
+++ b/docs/internal/security-model.md
@@ -1,0 +1,115 @@
+# Security Model
+
+**Audience:** plugin contributors and security reviewers.
+
+## Trust boundaries
+
+```
+                       ┌──────────────────────┐
+  Anonymous internet ──┤ Submit form (POST)   │── nonce + antispam + rate limit ──> swh_pre_ticket_create
+                       │ [submit_ticket]      │
+                       └──────────────────────┘
+
+                       ┌──────────────────────┐
+  Anonymous + token ───┤ Portal (GET/POST)    │── token hash_equals + TTL + rate limit ──> reply/close/reopen
+                       │ [helpdesk_portal]    │
+                       └──────────────────────┘
+
+                       ┌──────────────────────┐
+  Anonymous internet ──┤ REST inbound-email   │── Authorization: Bearer + [TKT-XXXX] + sender hash_equals
+                       │ POST /swh/v1/...     │
+                       └──────────────────────┘
+
+                       ┌──────────────────────┐
+  WP user (any)     ───┤ CSAT AJAX (nopriv)   │── nonce + ticket_id match
+                       │                      │
+                       └──────────────────────┘
+
+                       ┌──────────────────────┐
+  WP user (logged in) ─┤ My Tickets dashboard │── user_email == _ticket_email
+                       │                      │
+                       └──────────────────────┘
+
+                       ┌──────────────────────┐
+  Technician           ┤ Admin ticket editor  │── edit_post + (optional) restrict-to-assigned
+                       │                      │
+                       └──────────────────────┘
+
+                       ┌──────────────────────┐
+  Administrator        ┤ Settings + Tools     │── manage_options + nonce (two separate nonces)
+                       │                      │
+                       └──────────────────────┘
+```
+
+Everything to the left of the box is untrusted. The bullet to the right of the box is the mitigation that must hold or the boundary fails.
+
+## Threats and mitigations
+
+| Threat | Mitigation | Code location |
+|---|---|---|
+| Spam ticket submission | Honeypot field (`swh_website_url_hp`) zero-config + optional reCAPTCHA v2/Enterprise / Cloudflare Turnstile + per-IP rate limit. | `swh_check_antispam()` at `includes/helpers.php:375-458`; `swh_is_rate_limited()` at `helpers.php:777-794`. |
+| Portal token replay | Constant-time compare with `hash_equals`; optional TTL via `swh_token_expiration_days` (default 90; 0 disables). Pre-v1.9.0 tickets grandfathered (no `_ticket_token_created` → never expired). | `swh_is_token_expired()` at `helpers.php:336-346`; portal handlers in `frontend/class-portal.php`. |
+| Direct file URL access | `swh_serve_file()` proxy validates the resolved path starts inside `wp_get_upload_dir()['basedir']`. Attached files are served only through this proxy. `.htaccess` + `index.php` are written under `wp-content/uploads/swh-helpdesk/` to block direct listing. | `includes/class-ticket.php:21` (action priority 1 on `init`); `swh_ensure_upload_protection()` called from `swh_activate()` at `class-installer.php:55`. |
+| Inbound webhook spoofing | Three-factor: `Authorization: Bearer <swh_inbound_secret>` header; `[TKT-XXXX]` UID parsed from the subject; sender email compared to `_ticket_email` with `hash_equals`. All three must pass. | `swh_handle_inbound_email()` at `includes/class-email.php:222-`. |
+| CSRF on form submission | `wp_verify_nonce()` on every POST handler. `check_ajax_referer()` on AJAX. REST endpoints either rely on cookie+nonce (capability callback) or the Bearer secret. | Throughout. Canonical: AJAX merge at `simple-wp-helpdesk.php:184`. |
+| Privilege escalation via ticket comments | Reply comments are typed `helpdesk_reply` so they never leak into the site's default comment templates. Internal notes (`_is_internal_note=1`) are filtered out of frontend renderers in `frontend/class-portal.php`. | Comment-type migration at `class-installer.php:92-105`. |
+| XSS on rendered ticket content | `esc_html()` for text, `esc_attr()` for attributes, `wp_kses_post()` for admin-edited HTML fields. Translations with HTML use `wp_kses()` with an explicit allowlist (e.g. `<code>` only) — see `simple-wp-helpdesk.php:136`. | Throughout. |
+| Mass-assignment on ticket save | `swh_save_ticket_data()` in `admin/class-ticket-editor.php` reads only the documented input fields by name; no `$_POST` loop. | `admin/class-ticket-editor.php`. |
+| File upload abuse | Extension allowlist via `swh_allowed_file_types` filter (`jpg, jpeg, jpe, png, gif, pdf, doc, docx, txt` by default — `class-shortcode.php:57, 517`). Size/count limits (`swh_max_upload_size`, `swh_max_upload_count`). Uploads confined to `wp-content/uploads/swh-helpdesk/`. Retention cron prunes orphans. | `frontend/class-shortcode.php` upload handlers; retention cron at `includes/class-cron.php`. |
+| SQL injection | All raw SQL is parameterised through `$wpdb->prepare()`. The plugin runs no string-concatenated queries; direct queries (e.g. the comment-type migration at `class-installer.php:94-103` and the uninstall sweeps at `class-installer.php:228-229`) use `prepare()` or static string literals with no user input. | `class-installer.php:94-103, 228-229, 119`. |
+| Misconfigured anti-spam | Fails **closed**. Missing reCAPTCHA Enterprise credentials, invalid JSON response, or missing success flag all return `true` (i.e. "block submission"). | `helpers.php:392-393, 404, 421-422, 435-437, 453-455`. |
+| Side-channel timing on token compare | `hash_equals()` is used everywhere portal tokens are compared. | Portal handlers. |
+
+## Capability matrix
+
+| Action | Required capability | Additional gate |
+|---|---|---|
+| Submit a ticket | none (anonymous) | nonce + antispam + rate limit |
+| View own ticket via portal | none (token-authenticated) | `hash_equals` on token + TTL |
+| Reply via portal | none (token-authenticated) | `hash_equals` + rate limit (per-action key) |
+| Close own ticket via portal | none (token-authenticated) | `hash_equals` + rate limit (`portal_close_*`) |
+| Reopen own ticket via portal | none (token-authenticated) | `hash_equals` + rate limit (`portal_reopen_*` — distinct from close so immediate reopen is not blocked) |
+| Submit CSAT rating | none (nopriv AJAX) | nonce + ticket_id match |
+| View "My Tickets" dashboard | logged-in user | `wp_get_current_user()->user_email` equals `_ticket_email` of each shown ticket |
+| Edit a ticket (admin) | `edit_post` on the ticket | (optional) `swh_restrict_to_assigned=yes` filters to the technician's own tickets in the list query and direct `load-post.php` |
+| Bulk status change | `edit_post` on each ticket | nonce |
+| Inbound email webhook | none (Bearer-authenticated) | `Authorization: Bearer` + subject `[TKT-XXXX]` + sender `hash_equals` |
+| Merge tickets | `manage_options` | nonce |
+| Send test email | `manage_options` | nonce |
+| Save settings (main form) | `manage_options` | nonce (main) |
+| Save Tools / destructive options | `manage_options` | nonce (Tools — distinct from main) |
+| Read reporting | `manage_options` | nonce on AJAX |
+
+## Explicit non-threats
+
+The plugin does **not** defend against:
+
+- **End-user impersonation via a shared inbox account.** If two clients use the same email address they will see each other's tickets through the lookup form. Email ownership is the site operator's concern.
+- **WP admin compromise.** A user with `manage_options` can already do everything destructive the plugin offers (delete tickets, drop options, run uninstall). Site-level hardening is out of scope.
+- **DDoS at network layer.** Rate limiting is per-IP at application layer for spam mitigation; CDN/edge filtering is the operator's responsibility.
+- **Side-channel timing of `hash_equals` itself.** Assumed sufficient.
+- **Mailbox spoofing where SPF / DKIM / DMARC are not enforced upstream of the inbound webhook.** The webhook compares the parsed sender to `_ticket_email`. If the inbound mail pipeline accepts spoofed `From:` headers, the webhook will accept the spoof. Operators must enforce SPF/DKIM/DMARC at their MTA.
+
+## Security audit history
+
+No formal external audit. Continuous SAST coverage via:
+
+- Semgrep MCP server (developer-side, before commit).
+- `.github/workflows/semgrep.yml` on every PR.
+- PHPCS WordPress.Security rules.
+- PHPStan level 9.
+
+Findings are addressed in the PR that introduces or surfaces them.
+
+## Reporting vulnerabilities
+
+See `SECURITY.md` at the repository root.
+
+## Update protocol
+
+Update this doc when:
+- A new untrusted input surface is added (new public REST/AJAX endpoint, new shortcode handler, new file upload path).
+- An auth/authz flow changes (new capability check, new token type, new bypass path closed).
+- A mitigation is added, removed, or substantively changed.
+- A new explicit non-threat is recognised and documented.
+- A security audit (internal or external) produces findings worth recording.

--- a/docs/internal/security-model.md
+++ b/docs/internal/security-model.md
@@ -4,7 +4,7 @@
 
 ## Trust boundaries
 
-```
+```text
                        ┌──────────────────────┐
   Anonymous internet ──┤ Submit form (POST)   │── nonce + antispam + rate limit ──> swh_pre_ticket_create
                        │ [submit_ticket]      │

--- a/docs/internal/testing-guide.md
+++ b/docs/internal/testing-guide.md
@@ -1,0 +1,220 @@
+# Testing Guide
+
+**Audience:** plugin contributors.
+
+The pre-push hook calls `make test-docker`. A push without a green gate is rejected.
+
+## Test layers
+
+| Layer | Location | What it covers | Runtime |
+|---|---|---|---|
+| PHP lint | `make lint` | Syntax errors only. Catches typos before any other tool runs. | sub-second |
+| PHPCS (WPCS) | `make phpcs` | WordPress Coding Standards. Zero errors and zero warnings required. | seconds |
+| PHPStan | `make phpstan` | Level 9 static analysis. WP stubs via `szepeviktor/phpstan-wordpress`. | tens of seconds |
+| PHPUnit | `make phpunit` (`tests/Unit/`) | Pure-PHP logic in isolation. WordPress functions stubbed via `10up/wp_mock`. | seconds |
+| Semgrep | `make semgrep` | SAST rules from `--config=auto` and the bundled MCP server. | tens of seconds |
+| Coverage | `make coverage` → `coverage.xml` | PHPUnit Clover coverage. Requires pcov or xdebug. | tens of seconds |
+| Playwright E2E | `make e2e` / `make e2e-docker` | 64 sections in `testing/scripts/test_helpdesk_pw.py` against a real WP stack. | minutes |
+
+`make test` chains lint → phpcs → phpstan → phpunit → semgrep on the host. `make test-docker` runs the same chain inside the `phptest` container — preferred because no host PHP / Semgrep install is needed.
+
+## When to add what
+
+| Change | Required test |
+|---|---|
+| New user-facing feature | New numbered Playwright section. |
+| Bug fix (regression) | New or extended section that covers the bug scenario. |
+| Admin-only UI change | New or extended admin section. |
+| Pure logic helper (no WP API surface) | PHPUnit case under `tests/Unit/`. |
+| Internal refactor with no UX change | None required — but existing sections must still pass. |
+| Security fix | Extend or add a `security`-marked Playwright section. |
+
+If a change touches both logic and UX, both layers get tests.
+
+New Playwright sections continue from the next available number (currently 65). Add the section to the taxonomy table below.
+
+## How to run
+
+### Local gate
+
+```bash
+make test-docker         # Required before push. Full PHP gate in Docker.
+make e2e-docker          # Self-contained E2E: spin up + setup + test + teardown.
+make test-all            # test + e2e (host PHP path; requires WP_MODE=docker or SSH env).
+```
+
+### Individual tools
+
+```bash
+make lint                # PHP syntax check on all plugin files
+make phpcs               # WordPress Coding Standards
+vendor/bin/phpcbf && make phpcs   # auto-fix then re-check
+make phpstan             # Level 9
+make phpunit             # Unit tests
+make semgrep             # SAST
+make coverage            # → coverage.xml
+make bench               # Performance baseline against Docker stack (COUNT=N to override)
+```
+
+### Self-contained Docker E2E
+
+```bash
+make e2e-docker
+```
+
+Or manually:
+
+```bash
+docker compose -f docker-compose.test.yml up -d db wordpress wpcli mailhog
+bash docker/setup-test-wp.sh
+WP_MODE=docker MAILHOG_URL=http://localhost:8025 make e2e
+docker compose -f docker-compose.test.yml down -v
+```
+
+**MailHog:** when `MAILHOG_URL` is set and `WP_MODE=docker`, `expect_email()` asserts delivery via the MailHog API (`http://localhost:8025`). In SSH mode it falls back to the `EMAIL_CHECKS` summary printed at the end of the run for manual verification.
+
+### CodeRabbit
+
+After opening a PR, run `/review`. Address every actionable finding before merge.
+
+## Playwright test taxonomy
+
+64 sections in `testing/scripts/test_helpdesk_pw.py`. Marks: `smoke`, `security`, `slow`.
+
+| # | Name | Marks |
+|---|------|-------|
+| 01 | admin_auth | smoke |
+| 02 | plugin_verification | smoke |
+| 03 | ticket_submission | smoke |
+| 04 | admin_locate_ticket | smoke |
+| 05 | portal_url | |
+| 06 | admin_update_ticket | |
+| 07 | technician_workflow | |
+| 08 | client_portal | |
+| 09 | admin_verify_reply | |
+| 10 | portal_close_reopen | |
+| 11 | access_control | |
+| 12 | ticket_list_filters | |
+| 13 | ticket_lookup | |
+| 14 | accessibility | |
+| 15 | plugin_icons | slow |
+| 16 | honeypot_spam | security |
+| 17 | form_validation | security |
+| 18 | settings_persistence | |
+| 19 | canned_responses | |
+| 20 | bulk_status_change | |
+| 21 | tech2_workflow | |
+| 22 | admin_search_and_filters | |
+| 23 | file_attachments | slow |
+| 24 | portal_token_security | security |
+| 25 | xss_escaping | security |
+| 26 | subscriber_access_control | security |
+| 27 | rate_limiting | security |
+| 28 | cleanup | |
+| 29 | humanized_timestamps | |
+| 30 | resolved_cta_layout | |
+| 33 | csat_prompt | |
+| 34 | my_tickets_dashboard | |
+| 35 | portal_guest_lookup | |
+| 36 | shortcode_attrs | |
+| 37 | admin_list_filtering | |
+| 38 | admin_list_sorting | |
+| 39 | ticket_templates | |
+| 40 | first_response_time | |
+| 41 | cc_watchers | |
+| 42 | categories_taxonomy | |
+| 43 | ticket_merge | |
+| 44 | sla_breach_detection | |
+| 45 | assignment_rules | |
+| 46 | reporting_dashboard | |
+| 47 | inbound_email_webhook | |
+| 48 | timestamp_locale | |
+| 49 | dedicated_reply_buttons | |
+| 50 | unread_badge | |
+| 51 | unread_row_highlight | |
+| 52 | email_test_button | |
+| 53 | ux_a11y | |
+| 54 | responsive | |
+| 55 | email_branding | |
+| 56 | dark_mode | |
+| 57 | toast_notifications | |
+| 58 | reports_loading_states | |
+| 59 | admin_dark_mode | |
+| 60 | email_color_scheme | |
+| 61 | skip_to_content | |
+| 62 | focus_visible_rings | |
+| 63 | csat_focus_management | |
+| 64 | aria_live_announcements | |
+
+(Section numbers are not consecutive; some are reserved for now-merged work.)
+
+## Test architecture
+
+- **Session-scoped browser.** A single Chromium instance is shared across all tests so login cookies persist. Defined in `testing/scripts/conftest.py`.
+- **`check()`.** Soft-fail helper. Failures accumulate and surface after each test via an autouse fixture in `conftest.py`. Prefer `check()` over `assert` for non-blocking expectations.
+- **`skip()`.** Records a skip without aborting the section.
+- **`as_user(page, user, pass)`.** Context manager — logout, then login, then yield, then logout again.
+- **`wpcli(cmd)`.** Runs WP-CLI via SSH+docker exec (default), or `docker compose exec` when `WP_MODE=docker`. Returns the stdout string. **Exits non-zero for absent data** — `wp option get`, `wp post meta get`, `wp comment meta get` all exit 1 when the key is absent. This is a normal result; `wpcli()` returns an empty string and callers handle it.
+- **`_clear_rate_limits()`.** Deletes `swh_rl_*` rows from `wp_options` and flushes the object cache. The rate limiter uses `get_option()` which reads cache first, so both must be cleared.
+- **`_navigate_settings(page)`.** Navigates to settings and removes `.wp-pointer` elements. Security Ninja and other admin pointers intercept Playwright clicks otherwise.
+- **`state` dict.** Carries `ticket_id`, `ticket2_id`, `portal_url`, etc. across sections. Never hardcode an ID.
+- **`EMAIL_CHECKS` list.** Printed at end of run for manual verification in SSH mode. In Docker mode MailHog asserts automatically.
+
+## Key gotchas
+
+- **Meta key is `_ticket_status`** (underscore prefix). `wp post meta get` returns empty unless you include the underscore. Use `wp eval 'echo get_post_meta(ID, "_ticket_status", true);'` if the CLI behaves oddly.
+- **`required` attributes** must be stripped before JS form submit in validation tests, or HTML5 browser validation intercepts the submit and the POST never reaches the server.
+- **WordPress word-level search.** `LIKE '%Ticket%'` matches "Ticket" and "Ticket2" both. Avoid negative assertions based on title substrings.
+- **WP admin pointers.** Security Ninja and similar plugins inject `.wp-pointer` overlays that intercept Playwright clicks. Always call `_navigate_settings()` on settings page visits.
+- **Bulk action key format.** `sanitize_title('In Progress')` → `in-progress` → action value `swh_status_in-progress`.
+- **`expect_navigation()`.** Wrap JS-triggered form submits in `with page.expect_navigation():` to avoid a race between `evaluate` and `page.content()`.
+- **Canned response persistence check.** Read `el.value` via `page.evaluate()`. Input values are not in `inner_text()`.
+- **File upload form POST + caching plugins.** A page-caching plugin can fire an immediate GET after the file POST, overwriting the success HTML in the DOM. Use `expect_navigation()` + `wait_for_load_state("load")` to let it settle, then verify success via WP-CLI meta rather than `page.content()`.
+- **Authorization header stripped in Docker.** Apache strips the `Authorization` header before PHP receives it, regardless of `.htaccess` rules. For section 47 (inbound webhook), bypass HTTP entirely: construct a `WP_REST_Request` and call `swh_handle_inbound_email()` directly via `wp eval`.
+
+## Environment variables
+
+`testing/.env` is gitignored. Copy `testing/.env.example` and fill values. Required keys:
+
+| Variable | Purpose |
+|---|---|
+| `WP_URL`, `WP_LOGIN_URL`, `WP_ADMIN_URL`, `WP_SUBMIT_PAGE`, `WP_PORTAL_PAGE` | Test target URLs. |
+| `WP_ADMIN_USER`, `WP_ADMIN_PASS` | Admin login. |
+| `WP_TECH1_EMAIL`, `WP_TECH1_USER`, `WP_TECH1_PASS` | Technician 1. |
+| `WP_TECH2_USER`, `WP_TECH2_PASS` | Technician 2. |
+| `CLIENT1_NAME`, `CLIENT1_EMAIL` | Client 1 fixtures. |
+| `CLIENT2_NAME`, `CLIENT2_EMAIL` | Client 2 fixtures. |
+| `WP_MODE` | `ssh` (default) or `docker`. |
+| `SSH_HOST`, `WP_CONTAINER`, `WP_PATH` | Required when `WP_MODE=ssh`. |
+| `MAILHOG_URL` | MailHog API base, e.g. `http://localhost:8025`. Enables automated email assertions when `WP_MODE=docker`. |
+
+## Anti-patterns
+
+- Skipping the pre-push gate with `--no-verify`.
+- Asserting `inner_text()` for form input values (use `el.value` via `evaluate()`).
+- Adding network-dependent tests without a fallback path.
+- Hardcoding ticket IDs across sections — use the shared `state` dict.
+- Raising on non-zero `wpcli()` return — it is a normal result for absent meta.
+
+## CI configuration
+
+`.github/workflows/`:
+
+| File | Purpose |
+|---|---|
+| `php-tests.yml` | Lint, PHPCS, PHPStan, PHPUnit, Semgrep gate on push and PR. |
+| `e2e.yml` | Playwright E2E against the Docker stack on PR. |
+| `semgrep.yml` | Standalone Semgrep scan. |
+| `coverage.yml` | PHPUnit coverage report. |
+| `release.yml` | Builds `simple-wp-helpdesk.zip` and creates a GitHub Release on `v*.*.*` tag push. |
+| `claude.yml` | Claude Code automation hooks. |
+
+## Update protocol
+
+Update this doc when:
+- A new test layer is added (e.g. visual regression, performance gate).
+- A new Playwright section lands — bump the taxonomy table.
+- A new helper appears in `conftest.py`.
+- A new gotcha bites someone — add it to "Key gotchas" with reproduction.
+- An environment variable is added or renamed.
+- The CI workflow set changes.


### PR DESCRIPTION
## Summary

Establishes `docs/internal/` as the single source of truth for developer-and-agent project knowledge. Replaces the sprawling 398-line CLAUDE.md with a tight 133-line working-memory file that routes to the new docs.

## What's new

9 docs under `docs/internal/`:

| Doc | Lines | Purpose |
|---|---|---|
| `README.md` | 77 | Index, reading order, "when in doubt → which doc" routing |
| `design-document.md` | 184 | Architecture, repo layout, module map, **17 numbered load-bearing invariants** (each citing real file:line), design decisions, release engineering |
| `coding-guide.md` | 162 | Language baseline, naming, security hot list, sanitization/escaping table, error handling, comments policy, i18n, PR-time gates |
| `testing-guide.md` | 220 | Test layers, when-to-add-what, run commands, full 64-section Playwright taxonomy, architecture, gotchas, env vars, CI workflows |
| `security-model.md` | 115 | Trust boundaries, threats/mitigations, capability matrix, explicit non-threats |
| `api-contract.md` | 153 | Public-vs-internal line, SemVer + breaking-change taxonomy, 9 actions (pointer), 9 filters (enumerated from grep), REST + AJAX + shortcodes |
| `data-dictionary.md` | 151 | Storage map (no custom tables), 22 post meta + 4 comment meta keys (each verified by grep), transients, taxonomy, capabilities, migration policy |
| `config-reference.md` | 194 | 7-group taxonomy reflecting `swh_get_defaults()` exactly, `swh_get_option()` usage, override pattern, add-an-option process |
| `design-guide.md` | 91 | UX principles, when-to-use guidance, pointers to component-inventory.md + js-architecture.md |

Every doc ends with an **Update protocol** section listing concrete triggers — the docs stay accurate because keeping them current is part of the normal PR flow.

## CLAUDE.md trim

Was 398 lines → now 133 (-66%). Replacements:

| Removed | Now lives in |
|---|---|
| "Common Pitfalls" (20+ bullets) | `design-document.md` invariant table (17 numbered, with file:line citations) |
| Test Suite + Playwright Test Suite (~190 lines) | `testing-guide.md` |
| Security Conventions block | `security-model.md` |
| Repository Structure diagram | `design-document.md` |
| Release Process | `design-document.md` "Release engineering" |

What CLAUDE.md keeps: project overview, where-to-read routing table, 7 hot invariants for working memory, dev commands, PR-time gates table, dev environment (LSP/MCP/slash commands/plugin agents), auto-updater note.

## Design principles applied

- **Single source of truth** — each fact in one doc; others point at it
- **Audience-first** — every doc states its audience at the top
- **Maintainability over completeness** — every doc has an Update protocol
- **Code is the source for WHAT; these docs are the source for WHY**
- **Concrete > abstract** — every invariant cites a file:line range
- No emojis, no speculation, no backfilled ADRs, no PR/issue numbers in doc bodies

## PR-time gates wired

`coding-guide.md` codifies what to update when:

| Touching… | Update |
|---|---|
| Schema-ish state | `data-dictionary.md` |
| A setting | `config-reference.md` |
| Hook / REST / AJAX / shortcode attr | `api-contract.md` |
| Security posture | `security-model.md` |
| Shared CSS/JS primitive or token | `component-inventory.md` |
| User-facing feature/fix | New or extended Playwright section |

## Test plan

- [x] `make test-docker` — green (77/131)
- [ ] Spot-read each new doc; verify invariant citations resolve to real code
- [ ] Confirm no operator-facing content was moved out of `docs/*.md` (the user-facing tree is untouched)
- [ ] CodeRabbit `/review`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive internal docs set for v3.7.0: project overview, internal index/routing, API contract, coding & design guides, config reference, data dictionary, security model, testing guide, contributor/dev environment & workflow, plugins/agents inventory, and dev commands matrix. Consolidated hot invariants, introduced update protocols, and updated CHANGELOG to point to the new internal docs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seanmousseau/Simple-WP-Helpdesk/pull/401)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->