### PR TITLE
chore(deps): track @wordpress/scripts via Dependabot, suppress 5 stuck transitives

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,29 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+
+  # npm: only the @wordpress/scripts toolchain (build-only, not shipped to users).
+  # Transitive vulnerability advisories that are stuck behind unreleased upstream
+  # fixes are ignored — they will only be resolved when the upstream maintainer
+  # publishes a new @wordpress/scripts release with bumped deps.
+  # See docs/internal/lessons-learned.md "Dependabot: @wordpress/scripts transitive advisories".
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    allow:
+      - dependency-name: "@wordpress/scripts"
+    ignore:
+      # Transitive of webpack inside @wordpress/scripts. RCE via RegExp.flags
+      # (high) and CPU DoS via crafted array-likes (medium). Patched in 7.0.3
+      # and 7.0.5 respectively; @wordpress/scripts 32.1.0 still pins an older
+      # serialize-javascript transitively.
+      - dependency-name: "serialize-javascript"
+      # Transitive ReDoS via globstar segments. Patched in 3.1.3; pinned older
+      # by @wordpress/scripts' webpack stack.
+      - dependency-name: "minimatch"
+      # Source-theft when running `npm run start` and visiting a malicious
+      # site mid-session. Patched in 5.2.1. @wordpress/scripts 32.1.0 still
+      # pins 5.2.0. Build path (`npm run build`) is unaffected.
+      - dependency-name: "webpack-dev-server"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Theme: **v4 Foundations.** Non-breaking groundwork that de-risks v4.0 / v4.1. No
 
 ### Known follow-ups (deferred to a later release)
 
-- `@wordpress/scripts` toolchain reports 6 transitive build-time advisories (no runtime impact). Tracked for cleanup.
+- `@wordpress/scripts` toolchain reports 5 transitive build-time advisories (no runtime impact). Stuck behind upstream — `@wordpress/scripts` 32.1.0 is latest and still pins older `serialize-javascript`, `minimatch`, and `webpack-dev-server`. Will resolve when the upstream maintainer publishes a release with bumped transitives. Full assessment in `docs/internal/lessons-learned.md` → *Dependabot: `@wordpress/scripts` transitive advisories (2026-05-13)*. Dependabot config updated to watch `@wordpress/scripts` and ignore the stuck transitives.
 - `make bench` baseline currently captured at COUNT=100; 500/1000 runs deferred until v4.0 inbox work needs them.
 
 ---

--- a/docs/internal/lessons-learned.md
+++ b/docs/internal/lessons-learned.md
@@ -4,7 +4,7 @@ Things that bit us, what we learned, and how to avoid recurrence. Group by categ
 
 This complements `CLAUDE.md`'s "Common Pitfalls" section: that one is a quick checklist of code-level gotchas, this one is the longer-form *story* of what we ran into and what we changed because of it.
 
-Last updated: 2026-05-04
+Last updated: 2026-05-13
 
 ---
 
@@ -39,6 +39,38 @@ Last updated: 2026-05-04
 
 **What bit us (v3.4):** Push attempts failed silently when Docker Desktop was paused.
 **Lesson:** Pre-push hook (`make test-docker`) is the gate. There is no fallback. `git push --no-verify` exists but should never be used to bypass a real failure.
+
+### Dependabot: `@wordpress/scripts` transitive advisories (2026-05-13)
+
+**What surfaced (post v3.7.0 merge):** GitHub flagged 5 Dependabot security advisories on `main` immediately after the v3.7.0 PR landed — all in `package-lock.json`, all transitive deps of the `@wordpress/scripts` toolchain Phase 5 added:
+
+| Severity | Package | Vulnerable | Patched |
+|---|---|---|---|
+| high | `serialize-javascript` | ≤ 7.0.2 (RCE via `RegExp.flags`) | 7.0.3 |
+| medium | `serialize-javascript` | < 7.0.5 (CPU DoS via array-likes) | 7.0.5 |
+| high | `minimatch` | < 3.1.3 (ReDoS via globstar) | 3.1.3 |
+| medium | `webpack-dev-server` (×2) | ≤ 5.2.0 (source theft via malicious site) | 5.2.1 |
+
+**Assessment:**
+
+- `npm audit --omit=dev` → **0 vulnerabilities.** None ship to end users. Built `simple-wp-helpdesk/assets/dist/toast.js` is plain ES5 with zero bundled JS deps.
+- We were already on the **latest** `@wordpress/scripts` (32.1.0). `npm view @wordpress/scripts version` confirmed no newer release exists.
+- `npm audit fix` (non-forcing) found **no safe path** — the only autofix was `--force` downgrade to `@wordpress/scripts@19.2.4`, a breaking-major regression that would have lost asset.php emission and the ES-module pipeline.
+- `webpack-dev-server` only matters during `npm run start` (live-reload dev server). The build path (`npm run build`) is unaffected.
+
+**Conclusion:** stuck behind upstream. We can only update when `@wordpress/scripts` ships a patch. Forcing the issue is worse than the advisories.
+
+**What we did:**
+1. Added an `npm` ecosystem entry to `.github/dependabot.yml` with `allow: @wordpress/scripts` so future upstream releases auto-PR, and `ignore:` rules for the 3 stuck transitive packages (`serialize-javascript`, `minimatch`, `webpack-dev-server`) so the alert noise stops.
+2. Documented the assessment here so the next person who notices the alerts doesn't have to re-investigate.
+
+**Lesson:** Build-time-only transitive advisories with no upstream fix are best handled by:
+- Confirming `--omit=dev` is clean (production unaffected)
+- Confirming the top-level dep is at its latest version
+- Adding allow+ignore rules so the alert list stays meaningful for genuine production issues
+- Not force-downgrading the top-level dep just to clear a build-time alert
+
+**When to revisit:** `npm view @wordpress/scripts time --json | tail -5` periodically. When a 32.2.x or 33.x lands, bump and re-audit.
 
 ---
 


### PR DESCRIPTION
## Summary

GitHub's surfaced 5 Dependabot advisories on \`main\` after v3.7.0 merged — all transitive deps of \`@wordpress/scripts\`. This PR documents the assessment, configures Dependabot to track \`@wordpress/scripts\` itself (so genuine upstream updates surface as PRs), and suppresses the 3 stuck transitive packages so the alert list stays meaningful.

## Why suppress instead of fix?

| Severity | Package | Vulnerable | Patched |
|---|---|---|---|
| high | \`serialize-javascript\` | ≤ 7.0.2 (RCE via \`RegExp.flags\`) | 7.0.3 |
| medium | \`serialize-javascript\` | < 7.0.5 (CPU DoS via array-likes) | 7.0.5 |
| high | \`minimatch\` | < 3.1.3 (ReDoS via globstar) | 3.1.3 |
| medium | \`webpack-dev-server\` (×2) | ≤ 5.2.0 (source theft via malicious site) | 5.2.1 |

- \`npm audit --omit=dev\` → **0 vulnerabilities.** None ship to end users. Built \`assets/dist/toast.js\` is plain ES5 with zero bundled deps.
- We're already on the **latest** \`@wordpress/scripts\` (32.1.0). \`npm view\` confirms no newer release exists.
- \`npm audit fix\` finds no safe path. The only autofix is \`--force\` downgrade to \`@wordpress/scripts@19.2.4\` (breaking major regression).
- \`webpack-dev-server\` only triggers via \`npm run start\` (live-reload). The build path (\`npm run build\`) is unaffected.

**Conclusion:** stuck behind upstream. Forcing a downgrade is worse than the advisories.

## Changes

### \`.github/dependabot.yml\`

Adds an \`npm\` ecosystem entry (none existed — that's why no Dependabot PRs auto-opened):

- \`allow: @wordpress/scripts\` — only watch the top-level dep we want to update
- \`ignore:\` rules for the 3 transitives — silences alert churn until upstream ships a release with bumped deps

### \`docs/internal/lessons-learned.md\`

New entry **Dependabot: \`@wordpress/scripts\` transitive advisories (2026-05-13)** capturing the full assessment + re-check command so the next maintainer doesn't have to re-investigate.

### \`CHANGELOG.md\`

Updates the v3.7.0 "Known follow-ups" note from "6 transitive build-time advisories" to a precise reference pointing at the lessons-learned entry.

## When to revisit

\`\`\`bash
npm view @wordpress/scripts time --json | tail -5
\`\`\`

When \`32.2.x\` or \`33.x\` lands, bump and re-audit. Dependabot will auto-PR via the allow rule.

## Test plan

- [x] \`make test-docker\` — green (77/131)
- [x] No code changes; config + docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to monitor npm package updates on a weekly schedule.
  * Updated tracking of transitive security advisories.

* **Documentation**
  * Updated internal documentation to reflect recent dependency management actions and assessments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seanmousseau/Simple-WP-Helpdesk/pull/402)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->